### PR TITLE
Set ImGui path earlier in initialization to fix startup crash on ARM Macs

### DIFF
--- a/Common/src/main/java/foundry/veil/VeilClient.java
+++ b/Common/src/main/java/foundry/veil/VeilClient.java
@@ -7,6 +7,7 @@ import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.VeilRenderer;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
 import foundry.veil.impl.client.editor.*;
+import foundry.veil.impl.client.imgui.VeilImGuiImpl;
 import foundry.veil.impl.resource.VeilResourceManagerImpl;
 import foundry.veil.platform.VeilClientPlatform;
 import foundry.veil.platform.VeilEventPlatform;
@@ -28,6 +29,8 @@ public class VeilClient {
 
     @ApiStatus.Internal
     public static void init() {
+        VeilImGuiImpl.setImGuiPath();
+
         VeilEventPlatform.INSTANCE.onFreeNativeResources(() -> {
             VeilRenderSystem.close();
             RESOURCE_MANAGER.free();

--- a/Common/src/main/java/foundry/veil/impl/client/imgui/VeilImGuiImpl.java
+++ b/Common/src/main/java/foundry/veil/impl/client/imgui/VeilImGuiImpl.java
@@ -133,14 +133,18 @@ public class VeilImGuiImpl implements VeilImGui {
 
     public static void init(long window) {
         try {
-            if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64")) {
-                System.setProperty("imgui.library.name", "libimgui-javaarm64.dylib");
-            }
-
             instance = Veil.IMGUI ? new VeilImGuiImpl(window) : new InactiveVeilImGuiImpl();
         } catch (Throwable t) {
             Veil.LOGGER.error("Failed to load ImGui", t);
             instance = new InactiveVeilImGuiImpl();
+        }
+    }
+
+    public static void setImGuiPath() {
+        if (System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64")) {
+            // ImGui infers a path for loading the library using this name property
+            // Essential that this property is set, before any ImGui-adjacent native code is loaded
+            System.setProperty("imgui.library.name", "libimgui-javaarm64.dylib");
         }
     }
 


### PR DESCRIPTION
Tested on Fabric & Forge production, Forge breaks in dev for seemingly a different reason in which a separate PR will be submitted