### PR TITLE
Render JavaDoc using GitHub Actions

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
           java-version: 17
-          target-folder: common/build/docs/javadoc
+          javadoc-source-folder: common/build/docs/javadoc
           project: gradle
 
 

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -1,0 +1,21 @@
+name: Deploy Javadoc
+
+on:
+  push:
+    branches:
+      - 1.20
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # if you have a protection rule on your repository, you'll need to give write permission to the workflow.
+    steps:
+      - name: Deploy JavaDoc 🚀
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          javadoc-branch: javadoc
+          java-version: 17
+          target-folder: javadoc
+          project: gradle

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -34,3 +34,4 @@ jobs:
         run: |
           pwd
           ls -R
+        if: always()

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -11,6 +11,11 @@ jobs:
     permissions:
       contents: write  # if you have a protection rule on your repository, you'll need to give write permission to the workflow.
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+
       - name: Deploy JavaDoc 🚀
         uses: MathieuSoysal/Javadoc-publisher.yml@v2.5.0
         with:

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -28,3 +28,9 @@ jobs:
           java-version: 17
           target-folder: javadoc
           project: gradle
+
+
+      - name: Debug - List directory contents
+        run: |
+          pwd
+          ls -R

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc
           java-version: 17
-          target-folder: javadoc
+          target-folder: common/build/docs/javadoc
           project: gradle
 
 

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Debug - List directory contents
+        run: |
+          pwd
+          ls -R
 
       - name: Deploy JavaDoc 🚀
         uses: MathieuSoysal/Javadoc-publisher.yml@v2.5.0

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,11 @@ subprojects {
 
     java.toolchain.languageVersion = JavaLanguageVersion.of(17)
     java.withSourcesJar()
+
+    javadoc {
+        failOnError = false
+    }
+    
     jar {
         from(rootProject.file("LICENSE")) {
             rename { "${it}_${mod_name}" }


### PR DESCRIPTION
Render the JavaDoc to a branch (which you should put on GitHub Pages).
This is useful because you can see all the features at once and not have to search for it in the source code.
If you want, you can view the page on my fork.