### PR TITLE
Quasar: The Registrying

### DIFF
--- a/common/src/main/java/foundry/veil/VeilClient.java
+++ b/common/src/main/java/foundry/veil/VeilClient.java
@@ -7,6 +7,7 @@ import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.VeilRenderer;
 import foundry.veil.api.client.render.deferred.VeilDeferredRenderer;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.registry.EmitterShapeRegistry;
 import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.impl.client.editor.*;
@@ -74,6 +75,7 @@ public class VeilClient {
         VeilResourceEditorRegistry.bootstrap();
         EmitterShapeRegistry.bootstrap();
         RenderStyleRegistry.bootstrap();
+        ParticleModuleTypeRegistry.bootstrap();
     }
 
     @ApiStatus.Internal

--- a/common/src/main/java/foundry/veil/VeilClient.java
+++ b/common/src/main/java/foundry/veil/VeilClient.java
@@ -8,6 +8,7 @@ import foundry.veil.api.client.render.VeilRenderer;
 import foundry.veil.api.client.render.deferred.VeilDeferredRenderer;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
 import foundry.veil.api.quasar.registry.EmitterShapeRegistry;
+import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.impl.client.editor.*;
 import foundry.veil.impl.client.imgui.VeilImGuiImpl;
 import foundry.veil.impl.resource.VeilResourceManagerImpl;
@@ -72,6 +73,7 @@ public class VeilClient {
         RenderTypeLayerRegistry.bootstrap();
         VeilResourceEditorRegistry.bootstrap();
         EmitterShapeRegistry.bootstrap();
+        RenderStyleRegistry.bootstrap();
     }
 
     @ApiStatus.Internal

--- a/common/src/main/java/foundry/veil/VeilClient.java
+++ b/common/src/main/java/foundry/veil/VeilClient.java
@@ -7,6 +7,7 @@ import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.VeilRenderer;
 import foundry.veil.api.client.render.deferred.VeilDeferredRenderer;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
+import foundry.veil.api.quasar.registry.EmitterShapeRegistry;
 import foundry.veil.impl.client.editor.*;
 import foundry.veil.impl.client.imgui.VeilImGuiImpl;
 import foundry.veil.impl.resource.VeilResourceManagerImpl;
@@ -70,6 +71,7 @@ public class VeilClient {
         LightTypeRegistry.bootstrap();
         RenderTypeLayerRegistry.bootstrap();
         VeilResourceEditorRegistry.bootstrap();
+        EmitterShapeRegistry.bootstrap();
     }
 
     @ApiStatus.Internal

--- a/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
@@ -13,13 +13,13 @@ import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector3fc;
 
-public record EmitterShapeSettings(EmitterShape.Shape shape,
+public record EmitterShapeSettings(EmitterShape shape,
                                    Vector3fc dimensions,
                                    Vector3fc rotation,
                                    boolean fromSurface) {
 
     public static final Codec<EmitterShapeSettings> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            EmitterShape.Shape.CODEC.fieldOf("shape").forGetter(EmitterShapeSettings::shape),
+            EmitterShape.CODEC.fieldOf("shape").forGetter(EmitterShapeSettings::shape),
             CodecUtil.VECTOR3F_CODEC.fieldOf("dimensions").forGetter(EmitterShapeSettings::dimensions),
             CodecUtil.VECTOR3F_CODEC.fieldOf("rotation").forGetter(EmitterShapeSettings::rotation),
             Codec.BOOL.fieldOf("from_surface").forGetter(EmitterShapeSettings::fromSurface)

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
@@ -1,71 +1,93 @@
 package foundry.veil.api.quasar.data;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import foundry.veil.Veil;
 import foundry.veil.api.quasar.data.module.ModuleType;
+import foundry.veil.api.quasar.data.module.ParticleModuleData;
+import foundry.veil.api.quasar.data.module.collision.CollisionSubEmitterData;
+import foundry.veil.api.quasar.data.module.collision.DieOnCollisionModuleData;
+import foundry.veil.api.quasar.data.module.force.*;
+import foundry.veil.api.quasar.data.module.init.*;
+import foundry.veil.api.quasar.data.module.render.ColorParticleModuleData;
+import foundry.veil.api.quasar.data.module.render.TrailParticleModuleData;
+import foundry.veil.api.quasar.data.module.update.TickSizeParticleModuleData;
+import foundry.veil.api.quasar.data.module.update.TickSubEmitterModuleData;
+import foundry.veil.api.quasar.emitters.module.init.InitRandomRotationModuleData;
+import foundry.veil.api.util.CodecUtil;
+import foundry.veil.platform.registry.RegistrationProvider;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import org.jetbrains.annotations.ApiStatus;
 
 public class ParticleModuleTypeRegistry {
+    public static final ResourceKey<Registry<ModuleType<?>>> INIT_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/init"));
+    public static final ResourceKey<Registry<ModuleType<?>>> UPDATE_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/update"));
+    public static final ResourceKey<Registry<ModuleType<?>>> RENDER_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/render"));
 
-    private static final BiMap<String, ModuleType<?>> INIT_MODULES = HashBiMap.create();
-    private static final BiMap<String, ModuleType<?>> UPDATE_MODULES = HashBiMap.create();
-    private static final BiMap<String, ModuleType<?>> RENDER_MODULES = HashBiMap.create();
+    private static final RegistrationProvider<ModuleType<?>> INIT_MODULES_PROVIDER = RegistrationProvider.get(INIT_MODULES_KEY, Veil.MODID);
+    private static final RegistrationProvider<ModuleType<?>> UPDATE_MODULES_PROVIDER = RegistrationProvider.get(UPDATE_MODULES_KEY, Veil.MODID);
+    private static final RegistrationProvider<ModuleType<?>> RENDER_MODULES_PROVIDER = RegistrationProvider.get(RENDER_MODULES_KEY, Veil.MODID);
 
-    static {
-        ModuleType.bootstrap();
+    public static final Registry<ModuleType<?>> INIT_MODULES_REGISTRY = INIT_MODULES_PROVIDER.asVanillaRegistry();
+    public static final Registry<ModuleType<?>> UPDATE_MODULES_REGISTRY = UPDATE_MODULES_PROVIDER.asVanillaRegistry();
+    public static final Registry<ModuleType<?>> RENDER_MODULES_REGISTRY = RENDER_MODULES_PROVIDER.asVanillaRegistry();
+
+    public static final Codec<ModuleType<?>> INIT_MODULE_CODEC = CodecUtil.registryOrLegacyCodec(INIT_MODULES_REGISTRY);
+    public static final Codec<ModuleType<?>> UPDATE_MODULE_CODEC = CodecUtil.registryOrLegacyCodec(UPDATE_MODULES_REGISTRY);
+    public static final Codec<ModuleType<?>> RENDER_MODULE_CODEC = CodecUtil.registryOrLegacyCodec(RENDER_MODULES_REGISTRY);
+
+    // INIT
+    public static final ModuleType<InitialVelocityModuleData> INITIAL_VELOCITY = registerInitModule("initial_velocity", InitialVelocityModuleData.CODEC);
+    public static final ModuleType<ColorParticleModuleData> INIT_COLOR = registerInitModule("init_color", ColorParticleModuleData.CODEC);
+    public static final ModuleType<InitSubEmitterModuleData> INIT_SUB_EMITTER = registerInitModule("init_sub_emitter", InitSubEmitterModuleData.CODEC);
+    public static final ModuleType<InitSizeParticleModuleData> INIT_SIZE = registerInitModule("init_size", InitSizeParticleModuleData.CODEC);
+    //    ModuleType<InitRandomColorParticleModule> INIT_RANDOM_COLOR = registerInitModule("init_random_color", InitRandomColorParticleModule.CODEC);
+    public static final ModuleType<InitRandomRotationModuleData> INIT_RANDOM_ROTATION = registerInitModule("init_random_rotation", InitRandomRotationModuleData.CODEC);
+    public static final ModuleType<LightModuleData> LIGHT = registerInitModule("light", LightModuleData.CODEC);
+    public static final ModuleType<BlockParticleModuleData> BLOCK_PARTICLE = registerInitModule("block", BlockParticleModuleData.CODEC);
+
+    // RENDER
+    public static final ModuleType<TrailParticleModuleData> TRAIL = registerRenderModule("trail", TrailParticleModuleData.CODEC);
+    public static final ModuleType<ColorParticleModuleData> COLOR = registerRenderModule("color", ColorParticleModuleData.CODEC);
+    //    ModuleType<ColorOverTimeParticleModule> COLOR_OVER_LIFETIME = registerRenderModule("color_over_lifetime", ColorOverTimeParticleModule.CODEC);
+    //    ModuleType<ColorOverVelocityParticleModule> COLOR_OVER_VELOCITY = registerRenderModule("color_over_velocity", ColorOverVelocityParticleModule.CODEC);
+
+    // UPDATE
+    public static final ModuleType<TickSizeParticleModuleData> TICK_SIZE = registerUpdateModule("tick_size", TickSizeParticleModuleData.CODEC);
+    public static final ModuleType<TickSubEmitterModuleData> TICK_SUB_EMITTER = registerUpdateModule("tick_sub_emitter", TickSubEmitterModuleData.CODEC);
+    // UPDATE - COLLISION
+    public static final ModuleType<DieOnCollisionModuleData> DIE_ON_COLLISION = registerUpdateModule("die_on_collision", DieOnCollisionModuleData.CODEC);
+    public static final ModuleType<CollisionSubEmitterData> SUB_EMITTER_COLLISION = registerUpdateModule("sub_emitter_collision", CollisionSubEmitterData.CODEC);
+    //    ModuleType<BounceParticleModule> BOUNCE = registerUpdateModule("bounce", BounceParticleModule.CODEC);
+    // UPDATE - FORCES
+    public static final ModuleType<GravityForceData> GRAVITY = registerUpdateModule("gravity", GravityForceData.CODEC);
+    public static final ModuleType<VortexForceData> VORTEX = registerUpdateModule("vortex", VortexForceData.CODEC);
+    public static final ModuleType<PointAttractorForceData> POINT_ATTRACTOR = registerUpdateModule("point_attractor", PointAttractorForceData.CODEC);
+    public static final ModuleType<VectorFieldForceData> VECTOR_FIELD = registerUpdateModule("vector_field", VectorFieldForceData.CODEC);
+    public static final ModuleType<DragForceData> DRAG = registerUpdateModule("drag", DragForceData.CODEC);
+    public static final ModuleType<WindForceData> WIND = registerUpdateModule("wind", WindForceData.CODEC);
+    public static final ModuleType<PointForceData> POINT = registerUpdateModule("point_force", PointForceData.CODEC);
+
+    @ApiStatus.Internal
+    public static void bootstrap() {
     }
 
-    public static final Codec<ModuleType<?>> INIT_MODULE_CODEC = Codec.STRING.comapFlatMap(name -> {
-        ModuleType<?> module = INIT_MODULES.get(name);
-        if (module == null) {
-            return DataResult.error(() -> "Invalid Init Module: %s".formatted(name));
-        }
-        return DataResult.success(module);
-    }, INIT_MODULES.inverse()::get);
-
-    public static final Codec<ModuleType<?>> UPDATE_MODULE_CODEC = Codec.STRING.comapFlatMap(name -> {
-        ModuleType<?> module = UPDATE_MODULES.get(name);
-        if (module == null) {
-            return DataResult.error(() -> "Invalid Update Module: %s".formatted(name));
-        }
-        return DataResult.success(module);
-    }, UPDATE_MODULES.inverse()::get);
-
-    public static final Codec<ModuleType<?>> RENDER_MODULE_CODEC = Codec.STRING.comapFlatMap(name -> {
-        ModuleType<?> module = RENDER_MODULES.get(name);
-        if (module == null) {
-            return DataResult.error(() -> "Invalid Render Module: %s".formatted(name));
-        }
-        return DataResult.success(module);
-    }, RENDER_MODULES.inverse()::get);
-
-    public static void registerInit(String name, ModuleType<?> type) {
-        INIT_MODULES.put(name, type);
+    private static <T extends ParticleModuleData> ModuleType<T> registerUpdateModule(String name, Codec<T> codec) {
+        ModuleType<T> type = () -> codec;
+        UPDATE_MODULES_PROVIDER.register(name, () -> type);
+        return type;
     }
 
-    public static void registerUpdate(String name, ModuleType<?> type) {
-        UPDATE_MODULES.put(name, type);
+    private static <T extends ParticleModuleData> ModuleType<T> registerRenderModule(String name, Codec<T> codec) {
+        ModuleType<T> type = () -> codec;
+        RENDER_MODULES_PROVIDER.register(name, () -> type);
+        return type;
     }
 
-    public static void registerRender(String name, ModuleType<?> type) {
-        RENDER_MODULES.put(name, type);
-    }
-
-    public static String getName(ModuleType<?> type) {
-        String initModuleName = INIT_MODULES.inverse().get(type);
-        if (initModuleName != null) {
-            return initModuleName;
-        }
-        String updateModuleName = UPDATE_MODULES.inverse().get(type);
-        if (updateModuleName != null) {
-            return updateModuleName;
-        }
-        String renderModuleName = RENDER_MODULES.inverse().get(type);
-        if (renderModuleName != null) {
-            return renderModuleName;
-        }
-
-        return type.getClass().getName();
+    private static <T extends ParticleModuleData> ModuleType<T> registerInitModule(String name, Codec<T> codec) {
+        ModuleType<T> type = () -> codec;
+        INIT_MODULES_PROVIDER.register(name, () -> type);
+        return type;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
@@ -21,9 +21,9 @@ import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.ApiStatus;
 
 public class ParticleModuleTypeRegistry {
-    public static final ResourceKey<Registry<ModuleType<?>>> INIT_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/init"));
-    public static final ResourceKey<Registry<ModuleType<?>>> UPDATE_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/update"));
-    public static final ResourceKey<Registry<ModuleType<?>>> RENDER_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/modules/render"));
+    public static final ResourceKey<Registry<ModuleType<?>>> INIT_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/module_type/init"));
+    public static final ResourceKey<Registry<ModuleType<?>>> UPDATE_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/module_type/update"));
+    public static final ResourceKey<Registry<ModuleType<?>>> RENDER_MODULES_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/module_type/render"));
 
     private static final RegistrationProvider<ModuleType<?>> INIT_MODULES_PROVIDER = RegistrationProvider.get(INIT_MODULES_KEY, Veil.MODID);
     private static final RegistrationProvider<ModuleType<?>> UPDATE_MODULES_PROVIDER = RegistrationProvider.get(UPDATE_MODULES_KEY, Veil.MODID);

--- a/common/src/main/java/foundry/veil/api/quasar/data/QuasarParticleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/QuasarParticleData.java
@@ -5,7 +5,9 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.particle.QuasarParticle;
 import foundry.veil.api.quasar.particle.RenderData;
+import foundry.veil.api.quasar.particle.RenderStyle;
 import foundry.veil.api.quasar.particle.SpriteData;
+import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.RegistryFileCodec;
 import net.minecraft.resources.ResourceLocation;
@@ -47,7 +49,7 @@ public record QuasarParticleData(boolean shouldCollide,
                                  List<Holder<ParticleModuleData>> renderModules,
                                  @Nullable SpriteData spriteData,
                                  boolean additive,
-                                 RenderData.RenderStyle renderStyle) {
+                                 RenderStyle renderStyle) {
 
     public static final Codec<QuasarParticleData> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.BOOL.optionalFieldOf("should_collide", true).forGetter(QuasarParticleData::shouldCollide),
@@ -60,7 +62,7 @@ public record QuasarParticleData(boolean shouldCollide,
             ParticleModuleData.RENDER_CODEC.listOf().optionalFieldOf("render_modules", Collections.emptyList()).forGetter(QuasarParticleData::renderModules),
             SpriteData.CODEC.optionalFieldOf("sprite_data").forGetter(data -> Optional.ofNullable(data.spriteData())),
             Codec.BOOL.optionalFieldOf("additive", false).forGetter(QuasarParticleData::additive),
-            RenderData.RenderStyle.CODEC.optionalFieldOf("render_style", RenderData.RenderStyle.BILLBOARD).forGetter(QuasarParticleData::renderStyle)
+            RenderStyle.CODEC.optionalFieldOf("render_style", RenderStyleRegistry.BILLBOARD.get()).forGetter(QuasarParticleData::renderStyle)
     ).apply(instance, (shouldCollide, faceVelocity, velocityStretchFactor, initModules, updateModules, collisionModules, forceModules, renderModules, spriteData, additive, renderStyle) -> new QuasarParticleData(shouldCollide, faceVelocity, velocityStretchFactor, initModules, updateModules, collisionModules, forceModules, renderModules, spriteData.orElse(null), additive, renderStyle)));
     public static final Codec<Holder<QuasarParticleData>> CODEC = RegistryFileCodec.create(QuasarParticles.PARTICLE_DATA, DIRECT_CODEC);
 
@@ -74,7 +76,7 @@ public record QuasarParticleData(boolean shouldCollide,
                               List<Holder<ParticleModuleData>> renderModules,
                               @Nullable SpriteData spriteData,
                               boolean additive,
-                              RenderData.RenderStyle renderStyle) {
+                              RenderStyle renderStyle) {
         this.shouldCollide = shouldCollide;
         this.faceVelocity = faceVelocity;
         this.velocityStretchFactor = velocityStretchFactor;

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/ModuleType.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/ModuleType.java
@@ -1,85 +1,11 @@
 package foundry.veil.api.quasar.data.module;
 
 import com.mojang.serialization.Codec;
-import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
-import foundry.veil.api.quasar.data.module.collision.CollisionSubEmitterData;
-import foundry.veil.api.quasar.data.module.collision.DieOnCollisionModuleData;
-import foundry.veil.api.quasar.data.module.force.*;
-import foundry.veil.api.quasar.data.module.init.*;
-import foundry.veil.api.quasar.data.module.render.ColorParticleModuleData;
-import foundry.veil.api.quasar.data.module.render.TrailParticleModuleData;
-import foundry.veil.api.quasar.data.module.update.TickSizeParticleModuleData;
-import foundry.veil.api.quasar.data.module.update.TickSubEmitterModuleData;
-import foundry.veil.api.quasar.emitters.module.init.InitRandomRotationModuleData;
-import org.jetbrains.annotations.ApiStatus;
 
 @FunctionalInterface
 public interface ModuleType<T extends ParticleModuleData> {
-
-    // INIT
-    ModuleType<InitialVelocityModuleData> INITIAL_VELOCITY = registerInitModule("initial_velocity", InitialVelocityModuleData.CODEC);
-    ModuleType<ColorParticleModuleData> INIT_COLOR = registerInitModule("init_color", ColorParticleModuleData.CODEC);
-    ModuleType<InitSubEmitterModuleData> INIT_SUB_EMITTER = registerInitModule("init_sub_emitter", InitSubEmitterModuleData.CODEC);
-    ModuleType<InitSizeParticleModuleData> INIT_SIZE = registerInitModule("init_size", InitSizeParticleModuleData.CODEC);
-    //    ModuleType<InitRandomColorParticleModule> INIT_RANDOM_COLOR = registerInitModule("init_random_color", InitRandomColorParticleModule.CODEC);
-    ModuleType<InitRandomRotationModuleData> INIT_RANDOM_ROTATION = registerInitModule("init_random_rotation", InitRandomRotationModuleData.CODEC);
-    ModuleType<LightModuleData> LIGHT = registerInitModule("light", LightModuleData.CODEC);
-    ModuleType<BlockParticleModuleData> BLOCK_PARTICLE = registerInitModule("block", BlockParticleModuleData.CODEC);
-
-
-    // RENDER
-    ModuleType<TrailParticleModuleData> TRAIL = registerRenderModule("trail", TrailParticleModuleData.CODEC);
-    ModuleType<ColorParticleModuleData> COLOR = registerRenderModule("color", ColorParticleModuleData.CODEC);
-//    ModuleType<ColorOverTimeParticleModule> COLOR_OVER_LIFETIME = registerRenderModule("color_over_lifetime", ColorOverTimeParticleModule.CODEC);
-//    ModuleType<ColorOverVelocityParticleModule> COLOR_OVER_VELOCITY = registerRenderModule("color_over_velocity", ColorOverVelocityParticleModule.CODEC);
-
-    // UPDATE
-
-    ModuleType<TickSizeParticleModuleData> TICK_SIZE = registerUpdateModule("tick_size", TickSizeParticleModuleData.CODEC);
-    ModuleType<TickSubEmitterModuleData> TICK_SUB_EMITTER = registerUpdateModule("tick_sub_emitter", TickSubEmitterModuleData.CODEC);
-
-    // UPDATE - COLLISION
-    ModuleType<DieOnCollisionModuleData> DIE_ON_COLLISION = registerUpdateModule("die_on_collision", DieOnCollisionModuleData.CODEC);
-    ModuleType<CollisionSubEmitterData> SUB_EMITTER_COLLISION = registerUpdateModule("sub_emitter_collision", CollisionSubEmitterData.CODEC);
-//    ModuleType<BounceParticleModule> BOUNCE = registerUpdateModule("bounce", BounceParticleModule.CODEC);
-
-
-    // UPDATE - FORCES
-    ModuleType<GravityForceData> GRAVITY = registerUpdateModule("gravity", GravityForceData.CODEC);
-    ModuleType<VortexForceData> VORTEX = registerUpdateModule("vortex", VortexForceData.CODEC);
-    ModuleType<PointAttractorForceData> POINT_ATTRACTOR = registerUpdateModule("point_attractor", PointAttractorForceData.CODEC);
-    ModuleType<VectorFieldForceData> VECTOR_FIELD = registerUpdateModule("vector_field", VectorFieldForceData.CODEC);
-    ModuleType<DragForceData> DRAG = registerUpdateModule("drag", DragForceData.CODEC);
-    ModuleType<WindForceData> WIND = registerUpdateModule("wind", WindForceData.CODEC);
-    ModuleType<PointForceData> POINT = registerUpdateModule("point_force", PointForceData.CODEC);
-
     /**
      * @return The codec for this module type data
      */
     Codec<T> codec();
-
-    @ApiStatus.Internal
-    static void bootstrap() {
-    }
-
-    @ApiStatus.Internal
-    static <T extends ParticleModuleData> ModuleType<T> registerUpdateModule(String name, Codec<T> codec) {
-        ModuleType<T> type = () -> codec;
-        ParticleModuleTypeRegistry.registerUpdate(name, type);
-        return type;
-    }
-
-    @ApiStatus.Internal
-    static <T extends ParticleModuleData> ModuleType<T> registerRenderModule(String name, Codec<T> codec) {
-        ModuleType<T> type = () -> codec;
-        ParticleModuleTypeRegistry.registerRender(name, type);
-        return type;
-    }
-
-    @ApiStatus.Internal
-    static <T extends ParticleModuleData> ModuleType<T> registerInitModule(String name, Codec<T> codec) {
-        ModuleType<T> type = () -> codec;
-        ParticleModuleTypeRegistry.registerInit(name, type);
-        return type;
-    }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/collision/CollisionSubEmitterData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/collision/CollisionSubEmitterData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.collision;
 
 import com.mojang.serialization.Codec;
 import foundry.veil.api.client.render.VeilRenderSystem;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.CollisionParticleModule;
@@ -30,6 +31,6 @@ public record CollisionSubEmitterData(ResourceLocation subEmitter) implements Pa
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.SUB_EMITTER_COLLISION;
+        return ParticleModuleTypeRegistry.SUB_EMITTER_COLLISION;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/collision/DieOnCollisionModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/collision/DieOnCollisionModuleData.java
@@ -1,6 +1,7 @@
 package foundry.veil.api.quasar.data.module.collision;
 
 import com.mojang.serialization.Codec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.CollisionParticleModule;
@@ -18,6 +19,6 @@ public class DieOnCollisionModuleData implements ParticleModuleData {
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.DIE_ON_COLLISION;
+        return ParticleModuleTypeRegistry.DIE_ON_COLLISION;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/DragForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/DragForceData.java
@@ -1,6 +1,7 @@
 package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.ScaleForceModule;
@@ -25,6 +26,6 @@ public record DragForceData(double strength) implements ParticleModuleData {
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.DRAG;
+        return ParticleModuleTypeRegistry.DRAG;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/GravityForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/GravityForceData.java
@@ -1,6 +1,7 @@
 package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.ConstantForceModule;
@@ -21,6 +22,6 @@ public record GravityForceData(double strength) implements ParticleModuleData {
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.GRAVITY;
+        return ParticleModuleTypeRegistry.GRAVITY;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointAttractorForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointAttractorForceData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.PointAttractorForceModule;
@@ -52,6 +53,6 @@ public record PointAttractorForceData(Vector3dc position,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.POINT_ATTRACTOR;
+        return ParticleModuleTypeRegistry.POINT_ATTRACTOR;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointForceData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.PointForceModule;
@@ -32,6 +33,6 @@ public record PointForceData(Vector3dc point,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.POINT;
+        return ParticleModuleTypeRegistry.POINT;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/VectorFieldForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/VectorFieldForceData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.VectorFieldForceModule;
@@ -29,6 +30,6 @@ public record VectorFieldForceData(VectorField vectorField,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.VECTOR_FIELD;
+        return ParticleModuleTypeRegistry.VECTOR_FIELD;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/VortexForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/VortexForceData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.VortexForceModule;
@@ -39,6 +40,6 @@ public record VortexForceData(Vector3dc vortexAxis,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.VORTEX;
+        return ParticleModuleTypeRegistry.VORTEX;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/WindForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/WindForceData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.force;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.force.ConstantForceModule;
@@ -39,6 +40,6 @@ public record WindForceData(Vector3dc windDirection,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.WIND;
+        return ParticleModuleTypeRegistry.WIND;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/BlockParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/BlockParticleModuleData.java
@@ -1,6 +1,7 @@
 package foundry.veil.api.quasar.data.module.init;
 
 import com.mojang.serialization.Codec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -33,6 +34,6 @@ public record BlockParticleModuleData(boolean dynamic) implements ParticleModule
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.BLOCK_PARTICLE;
+        return ParticleModuleTypeRegistry.BLOCK_PARTICLE;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitSizeParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitSizeParticleModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.init;
 
 import com.mojang.serialization.Codec;
 import foundry.veil.api.molang.MolangExpressionCodec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -27,6 +28,6 @@ public record InitSizeParticleModuleData(MolangExpression size) implements Parti
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.INIT_SIZE;
+        return ParticleModuleTypeRegistry.INIT_SIZE;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitSubEmitterModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitSubEmitterModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.init;
 
 import com.mojang.serialization.Codec;
 import foundry.veil.api.client.render.VeilRenderSystem;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -30,6 +31,6 @@ public record InitSubEmitterModuleData(ResourceLocation subEmitter) implements P
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.INIT_SUB_EMITTER;
+        return ParticleModuleTypeRegistry.INIT_SUB_EMITTER;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitialVelocityModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitialVelocityModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.init;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -29,6 +30,6 @@ public record InitialVelocityModuleData(Vector3dc velocityDirection,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.INITIAL_VELOCITY;
+        return ParticleModuleTypeRegistry.INITIAL_VELOCITY;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/LightModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/LightModuleData.java
@@ -3,6 +3,7 @@ package foundry.veil.api.quasar.data.module.init;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import foundry.veil.api.molang.MolangExpressionCodec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.render.DynamicLightModule;
@@ -35,6 +36,6 @@ public record LightModuleData(ColorGradient color,
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.LIGHT;
+        return ParticleModuleTypeRegistry.LIGHT;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/render/ColorParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/render/ColorParticleModuleData.java
@@ -3,6 +3,7 @@ package foundry.veil.api.quasar.data.module.render;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import foundry.veil.api.molang.MolangExpressionCodec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -30,6 +31,6 @@ public record ColorParticleModuleData(ColorGradient gradient, MolangExpression i
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.INIT_COLOR;
+        return ParticleModuleTypeRegistry.INIT_COLOR;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/render/TrailParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/render/TrailParticleModuleData.java
@@ -1,6 +1,7 @@
 package foundry.veil.api.quasar.data.module.render;
 
 import com.mojang.serialization.Codec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.RenderParticleModule;
@@ -33,6 +34,6 @@ public record TrailParticleModuleData(List<TrailSettings> settings) implements P
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.TRAIL;
+        return ParticleModuleTypeRegistry.TRAIL;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickSizeParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickSizeParticleModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.update;
 
 import com.mojang.serialization.Codec;
 import foundry.veil.api.molang.MolangExpressionCodec;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.UpdateParticleModule;
@@ -27,6 +28,6 @@ public record TickSizeParticleModuleData(MolangExpression size) implements Parti
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.TICK_SIZE;
+        return ParticleModuleTypeRegistry.TICK_SIZE;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickSubEmitterModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickSubEmitterModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.data.module.update;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.update.TickSubEmitterModule;
@@ -22,6 +23,6 @@ public record TickSubEmitterModuleData(ResourceLocation subEmitter, int frequenc
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.TICK_SUB_EMITTER;
+        return ParticleModuleTypeRegistry.TICK_SUB_EMITTER;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/init/InitRandomRotationModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/init/InitRandomRotationModuleData.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.emitters.module.init;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
 import foundry.veil.api.quasar.data.module.ModuleType;
 import foundry.veil.api.quasar.data.module.ParticleModuleData;
 import foundry.veil.api.quasar.emitters.module.InitParticleModule;
@@ -27,6 +28,6 @@ public record InitRandomRotationModuleData(Vector3fc minDegrees, Vector3fc maxDe
 
     @Override
     public ModuleType<?> getType() {
-        return ModuleType.INIT_RANDOM_ROTATION;
+        return ParticleModuleTypeRegistry.INIT_RANDOM_ROTATION;
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/update/FaceVelocityModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/update/FaceVelocityModule.java
@@ -3,6 +3,7 @@ package foundry.veil.api.quasar.emitters.module.update;
 import foundry.veil.api.quasar.emitters.module.UpdateParticleModule;
 import foundry.veil.api.quasar.particle.QuasarParticle;
 import foundry.veil.api.quasar.particle.RenderData;
+import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import net.minecraft.util.Mth;
 import org.joml.Vector3d;
 import org.joml.Vector3f;
@@ -21,7 +22,7 @@ public class FaceVelocityModule implements UpdateParticleModule {
         Vector3f rotation = particle.getRotation();
         rotation.x = (float) Mth.atan2(normalizedMotion.y, Math.sqrt(normalizedMotion.x * normalizedMotion.x + normalizedMotion.z * normalizedMotion.z));
         rotation.y = (float) Mth.atan2(normalizedMotion.x, normalizedMotion.z);
-        if (particle.getData().renderStyle() == RenderData.RenderStyle.BILLBOARD) {
+        if (particle.getData().renderStyle() == RenderStyleRegistry.BILLBOARD.get()) {
             rotation.y += (float) (Math.PI / 2.0);
         }
     }

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/EmitterShape.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/EmitterShape.java
@@ -2,14 +2,23 @@ package foundry.veil.api.quasar.emitters.shape;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import foundry.veil.Veil;
+import foundry.veil.api.quasar.registry.EmitterShapeRegistry;
+import foundry.veil.api.util.CodecUtil;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector3fc;
 
 import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
 
 public interface EmitterShape {
 
@@ -17,38 +26,5 @@ public interface EmitterShape {
 
     void renderShape(PoseStack stack, VertexConsumer consumer, Vector3fc dimensions, Vector3fc rotation);
 
-    enum Shape implements EmitterShape {
-        POINT(new Point()),
-        HEMISPHERE(new Hemisphere()),
-        CYLINDER(new Cylinder()),
-        SPHERE(new Sphere()),
-        CUBE(new Cube()),
-        TORUS(new Torus()),
-        DISC(new Disc()),
-        PLANE(new Plane());
-
-        public static final Codec<Shape> CODEC = Codec.STRING.flatXmap(name -> {
-            for (Shape value : Shape.values()) {
-                if (value.name().equalsIgnoreCase(name)) {
-                    return DataResult.success(value);
-                }
-            }
-            return DataResult.error(() -> "Unknown shape: " + name, POINT);
-        }, shape -> DataResult.success(shape.name().toLowerCase(Locale.ROOT)));
-        private final EmitterShape shape;
-
-        Shape(EmitterShape shape) {
-            this.shape = shape;
-        }
-
-        @Override
-        public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
-            return this.shape.getPoint(randomSource, dimensions, rotation, position, fromSurface);
-        }
-
-        @Override
-        public void renderShape(PoseStack stack, VertexConsumer consumer, Vector3fc dimensions, Vector3fc rotation) {
-            this.shape.renderShape(stack, consumer, dimensions, rotation);
-        }
-    }
+    Codec<EmitterShape> CODEC = CodecUtil.registryOrLegacyCodec(EmitterShapeRegistry.REGISTRY);
 }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -214,7 +214,7 @@ public class ParticleEmitter {
     @ApiStatus.Internal
     public void render(PoseStack poseStack, MultiBufferSource bufferSource, Camera camera, float partialTicks) {
         Vec3 projectedView = camera.getPosition();
-        RenderData.RenderStyle renderStyle = this.particleData.renderStyle();
+        RenderStyle renderStyle = this.particleData.renderStyle();
 
         Vector3f renderOffset = new Vector3f();
         RenderType lastRenderType = null;

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderData.java
@@ -1,14 +1,10 @@
 package foundry.veil.api.quasar.particle;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
 import foundry.veil.Veil;
 import foundry.veil.api.client.render.rendertype.VeilRenderType;
 import foundry.veil.api.quasar.data.QuasarParticleData;
 import foundry.veil.api.quasar.fx.Trail;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -28,29 +24,6 @@ public class RenderData {
 
     @Deprecated
     private static final ResourceLocation BLANK = Veil.veilPath("textures/special/blank.png");
-
-    private static final Vector3fc[] PLANE_POSITIONS = {
-            // plane from -1 to 1 on Y axis and -1 to 1 on X axis
-            new Vector3f(1, -1, 0), new Vector3f(-1, -1, 0), new Vector3f(-1, 1, 0), new Vector3f(1, 1, 0)
-    };
-    private static final Vector3fc[] CUBE_POSITIONS = {
-            // TOP
-            new Vector3f(1, 1, -1), new Vector3f(1, 1, 1), new Vector3f(-1, 1, 1), new Vector3f(-1, 1, -1),
-
-            // BOTTOM
-            new Vector3f(-1, -1, -1), new Vector3f(-1, -1, 1), new Vector3f(1, -1, 1), new Vector3f(1, -1, -1),
-
-            // FRONT
-            new Vector3f(-1, -1, 1), new Vector3f(-1, 1, 1), new Vector3f(1, 1, 1), new Vector3f(1, -1, 1),
-
-            // BACK
-            new Vector3f(1, -1, -1), new Vector3f(1, 1, -1), new Vector3f(-1, 1, -1), new Vector3f(-1, -1, -1),
-
-            // LEFT
-            new Vector3f(-1, -1, -1), new Vector3f(-1, 1, -1), new Vector3f(-1, 1, 1), new Vector3f(-1, -1, 1),
-
-            // RIGHT
-            new Vector3f(1, -1, 1), new Vector3f(1, 1, 1), new Vector3f(1, 1, -1), new Vector3f(1, -1, -1)};
 
     private final Vector3d prevPosition;
     private final Vector3d renderPosition;
@@ -227,118 +200,5 @@ public class RenderData {
     public void setAtlasSprite(@Nullable TextureAtlasSprite atlasSprite) {
         this.atlasSprite = atlasSprite;
         this.updateRenderType();
-    }
-
-    public enum RenderStyle {
-        CUBE {
-            @Override
-            public void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-                Matrix4f matrix4f = poseStack.last().pose();
-                Vector3fc rotation = renderData.getRenderRotation();
-                Vector3f vec = new Vector3f();
-                SpriteData spriteData = renderData.getSpriteData();
-
-                for (int i = 0; i < 6; i++) {
-                    for (int j = 0; j < 4; j++) {
-                        vec.set(CUBE_POSITIONS[i * 4 + j]);
-                        QuasarParticleData data = particle.getData();
-                        if (vec.z < 0 && data.velocityStretchFactor() != 0.0f) {
-                            vec.z *= 1 + data.velocityStretchFactor();
-                        }
-                        vec.rotateX(rotation.x())
-                                .rotateY(rotation.y())
-                                .rotateZ(rotation.z())
-                                .mul((float) (renderData.getRenderRadius() * ageModifier))
-                                .add(renderOffset);
-
-                        float u = (int) (j / 2.0F);
-                        float v = j % 2;
-
-                        if (spriteData != null) {
-                            u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
-                            v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
-                        }
-
-                        builder.vertex(matrix4f, vec.x, vec.y, vec.z);
-                        builder.uv(u, v);
-                        builder.color(renderData.getRed(), renderData.getGreen(), renderData.getBlue(), renderData.getAlpha());
-                        builder.uv2(renderData.getLightColor());
-                        builder.endVertex();
-                    }
-                }
-            }
-        },
-        // TODO: FIX UVS THEY'RE FUCKED
-        BILLBOARD {
-            @Override
-            public void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-                Matrix4f matrix4f = poseStack.last().pose();
-                Vector3fc rotation = renderData.getRenderRotation();
-
-                Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation();
-                SpriteData spriteData = renderData.getSpriteData();
-
-                int red = (int) (renderData.getRed() * 255.0F) & 0xFF;
-                int green = (int) (renderData.getGreen() * 255.0F) & 0xFF;
-                int blue = (int) (renderData.getBlue() * 255.0F) & 0xFF;
-                int alpha = (int) (renderData.getAlpha() * 255.0F) & 0xFF;
-
-                // turn quat into pitch and yaw
-                Vector3f vec = new Vector3f();
-                for (int j = 0; j < 4; j++) {
-                    vec.set(PLANE_POSITIONS[j]);
-                    if (particle.getData().velocityStretchFactor() > 0f) {
-                        vec.set(vec.x * (1 + particle.getData().velocityStretchFactor()), vec.y, vec.z);
-                    }
-                    if (particle.getData().faceVelocity()) {
-                        vec.rotateX(rotation.x())
-                                .rotateY(rotation.y())
-                                .rotateZ(rotation.z());
-                    }
-//                vec = vec.xRot(lerpedPitch).yRot(lerpedYaw).zRot(lerpedRoll);
-                    faceCameraRotation.transform(vec).mul((float) (renderData.getRenderRadius() * ageModifier)).add(renderOffset);
-
-                    float u, v;
-                    if (j == 0) {
-                        u = 0;
-                        v = 0;
-                    } else if (j == 1) {
-                        u = 1;
-                        v = 0;
-                    } else if (j == 2) {
-                        u = 1;
-                        v = 1;
-                    } else {
-                        u = 0;
-                        v = 1;
-                    }
-                    if (spriteData != null) {
-                        u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
-                        v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
-                    }
-//                    if (particle.sprite != null) {
-//                        u1 = u;
-//                        v1 = v;
-//                    }
-                    builder.vertex(matrix4f, vec.x, vec.y, vec.z);
-                    builder.uv(u, v);
-                    builder.color(red, green, blue, alpha);
-                    builder.uv2(renderData.getLightColor());
-                    builder.endVertex();
-                }
-            }
-        };
-
-        private static final Map<String, RenderStyle> VALUES = Arrays.stream(values()).collect(Collectors.toMap(v -> v.name().toLowerCase(Locale.ROOT), v -> v));
-        public static final Codec<RenderStyle> CODEC = Codec.STRING.flatXmap(name -> {
-            String key = name.toLowerCase(Locale.ROOT);
-            RenderStyle renderStyle = VALUES.get(key);
-            if (renderStyle == null) {
-                return DataResult.error(() -> "Invalid Render Style: " + key);
-            }
-            return DataResult.success(renderStyle);
-        }, style -> DataResult.success(style.name().toLowerCase(Locale.ROOT)));
-
-        public abstract void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks);
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -1,0 +1,146 @@
+package foundry.veil.api.quasar.particle;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import foundry.veil.api.quasar.data.QuasarParticleData;
+import foundry.veil.api.quasar.registry.RenderStyleRegistry;
+import foundry.veil.api.util.CodecUtil;
+import net.minecraft.client.Minecraft;
+import org.joml.Matrix4f;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+
+import java.util.Locale;
+
+public interface RenderStyle {
+    Codec<RenderStyle> CODEC = CodecUtil.registryOrLegacyCodec(RenderStyleRegistry.REGISTRY);
+
+    void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks);
+
+    final class Cube implements RenderStyle {
+        private static final Vector3fc[] CUBE_POSITIONS = {
+                // TOP
+                new Vector3f(1, 1, -1), new Vector3f(1, 1, 1), new Vector3f(-1, 1, 1), new Vector3f(-1, 1, -1),
+
+                // BOTTOM
+                new Vector3f(-1, -1, -1), new Vector3f(-1, -1, 1), new Vector3f(1, -1, 1), new Vector3f(1, -1, -1),
+
+                // FRONT
+                new Vector3f(-1, -1, 1), new Vector3f(-1, 1, 1), new Vector3f(1, 1, 1), new Vector3f(1, -1, 1),
+
+                // BACK
+                new Vector3f(1, -1, -1), new Vector3f(1, 1, -1), new Vector3f(-1, 1, -1), new Vector3f(-1, -1, -1),
+
+                // LEFT
+                new Vector3f(-1, -1, -1), new Vector3f(-1, 1, -1), new Vector3f(-1, 1, 1), new Vector3f(-1, -1, 1),
+
+                // RIGHT
+                new Vector3f(1, -1, 1), new Vector3f(1, 1, 1), new Vector3f(1, 1, -1), new Vector3f(1, -1, -1)};
+
+        @Override
+        public void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
+            Matrix4f matrix4f = poseStack.last().pose();
+            Vector3fc rotation = renderData.getRenderRotation();
+            Vector3f vec = new Vector3f();
+            SpriteData spriteData = renderData.getSpriteData();
+
+            for (int i = 0; i < 6; i++) {
+                for (int j = 0; j < 4; j++) {
+                    vec.set(CUBE_POSITIONS[i * 4 + j]);
+                    QuasarParticleData data = particle.getData();
+                    if (vec.z < 0 && data.velocityStretchFactor() != 0.0f) {
+                        vec.z *= 1 + data.velocityStretchFactor();
+                    }
+                    vec.rotateX(rotation.x())
+                            .rotateY(rotation.y())
+                            .rotateZ(rotation.z())
+                            .mul((float) (renderData.getRenderRadius() * ageModifier))
+                            .add(renderOffset);
+
+                    float u = (int) (j / 2.0F);
+                    float v = j % 2;
+
+                    if (spriteData != null) {
+                        u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
+                        v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
+                    }
+
+                    builder.vertex(matrix4f, vec.x, vec.y, vec.z);
+                    builder.uv(u, v);
+                    builder.color(renderData.getRed(), renderData.getGreen(), renderData.getBlue(), renderData.getAlpha());
+                    builder.uv2(renderData.getLightColor());
+                    builder.endVertex();
+                }
+            }
+        }
+    }
+
+    final class Billboard implements RenderStyle {
+        private static final Vector3fc[] PLANE_POSITIONS = {
+                // plane from -1 to 1 on Y axis and -1 to 1 on X axis
+                new Vector3f(1, -1, 0), new Vector3f(-1, -1, 0), new Vector3f(-1, 1, 0), new Vector3f(1, 1, 0)
+        };
+
+        @Override
+        public void render(PoseStack poseStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
+            //TODO fix UVs theyre fucked
+            Matrix4f matrix4f = poseStack.last().pose();
+            Vector3fc rotation = renderData.getRenderRotation();
+
+            Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation();
+            SpriteData spriteData = renderData.getSpriteData();
+
+            int red = (int) (renderData.getRed() * 255.0F) & 0xFF;
+            int green = (int) (renderData.getGreen() * 255.0F) & 0xFF;
+            int blue = (int) (renderData.getBlue() * 255.0F) & 0xFF;
+            int alpha = (int) (renderData.getAlpha() * 255.0F) & 0xFF;
+
+            // turn quat into pitch and yaw
+            Vector3f vec = new Vector3f();
+            for (int j = 0; j < 4; j++) {
+                vec.set(PLANE_POSITIONS[j]);
+                if (particle.getData().velocityStretchFactor() > 0f) {
+                    vec.set(vec.x * (1 + particle.getData().velocityStretchFactor()), vec.y, vec.z);
+                }
+                if (particle.getData().faceVelocity()) {
+                    vec.rotateX(rotation.x())
+                            .rotateY(rotation.y())
+                            .rotateZ(rotation.z());
+                }
+//                vec = vec.xRot(lerpedPitch).yRot(lerpedYaw).zRot(lerpedRoll);
+                faceCameraRotation.transform(vec).mul((float) (renderData.getRenderRadius() * ageModifier)).add(renderOffset);
+
+                float u, v;
+                if (j == 0) {
+                    u = 0;
+                    v = 0;
+                } else if (j == 1) {
+                    u = 1;
+                    v = 0;
+                } else if (j == 2) {
+                    u = 1;
+                    v = 1;
+                } else {
+                    u = 0;
+                    v = 1;
+                }
+                if (spriteData != null) {
+                    u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
+                    v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
+                }
+//                    if (particle.sprite != null) {
+//                        u1 = u;
+//                        v1 = v;
+//                    }
+                builder.vertex(matrix4f, vec.x, vec.y, vec.z);
+                builder.uv(u, v);
+                builder.color(red, green, blue, alpha);
+                builder.uv2(renderData.getLightColor());
+                builder.endVertex();
+            }
+        }
+    }
+}

--- a/common/src/main/java/foundry/veil/api/quasar/registry/EmitterShapeRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/registry/EmitterShapeRegistry.java
@@ -1,0 +1,43 @@
+package foundry.veil.api.quasar.registry;
+
+import com.mojang.serialization.Codec;
+import foundry.veil.Veil;
+import foundry.veil.api.client.render.post.PostPipeline;
+import foundry.veil.api.client.render.post.stage.BlitPostStage;
+import foundry.veil.api.client.render.post.stage.CopyPostStage;
+import foundry.veil.api.client.render.post.stage.DepthFunctionPostStage;
+import foundry.veil.api.client.render.post.stage.MaskPostStage;
+import foundry.veil.api.quasar.emitters.shape.*;
+import foundry.veil.platform.registry.RegistrationProvider;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.function.Supplier;
+
+/**
+ * Registry for all emitter shapes.
+ */
+public class EmitterShapeRegistry {
+
+    public static final ResourceKey<Registry<EmitterShape>> REGISTRY_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/emitter_shape"));
+    private static final RegistrationProvider<EmitterShape> PROVIDER = RegistrationProvider.get(REGISTRY_KEY, Veil.MODID);
+    public static final Registry<EmitterShape> REGISTRY = PROVIDER.asVanillaRegistry();
+
+    public static final Supplier<Point> POINT = register("point", new Point());
+    public static final Supplier<Hemisphere> HEMISPHERE = register("hemisphere", new Hemisphere());
+    public static final Supplier<Cylinder> CYLINDER = register("cylinder", new Cylinder());
+    public static final Supplier<Sphere> SPHERE = register("sphere", new Sphere());
+    public static final Supplier<Cube> CUBE = register("cube", new Cube());
+    public static final Supplier<Torus> TORUS = register("torus", new Torus());
+    public static final Supplier<Disc> DISC = register("disc", new Disc());
+    public static final Supplier<Plane> PLANE = register("plane", new Plane());
+
+    @ApiStatus.Internal
+    public static void bootstrap() {
+    }
+
+    private static <T extends EmitterShape> Supplier<T> register(String name, T shape) {
+        return PROVIDER.register(name, () -> shape);
+    }
+}

--- a/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
@@ -1,0 +1,33 @@
+package foundry.veil.api.quasar.registry;
+
+import foundry.veil.Veil;
+import foundry.veil.api.quasar.emitters.shape.*;
+import foundry.veil.api.quasar.particle.RenderData;
+import foundry.veil.api.quasar.particle.RenderStyle;
+import foundry.veil.platform.registry.RegistrationProvider;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.function.Supplier;
+
+/**
+ * Registry for all render styles.
+ */
+public class RenderStyleRegistry {
+
+    public static final ResourceKey<Registry<RenderStyle>> REGISTRY_KEY = ResourceKey.createRegistryKey(Veil.veilPath("quasar/render_style"));
+    private static final RegistrationProvider<RenderStyle> PROVIDER = RegistrationProvider.get(REGISTRY_KEY, Veil.MODID);
+    public static final Registry<RenderStyle> REGISTRY = PROVIDER.asVanillaRegistry();
+
+    public static final Supplier<RenderStyle.Cube> CUBE = register("cube", new RenderStyle.Cube());
+    public static final Supplier<RenderStyle.Billboard> BILLBOARD = register("billboard", new RenderStyle.Billboard());
+
+    @ApiStatus.Internal
+    public static void bootstrap() {
+    }
+
+    private static <T extends RenderStyle> Supplier<T> register(String name, T shape) {
+        return PROVIDER.register(name, () -> shape);
+    }
+}

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/basic_smoke.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/basic_smoke.json
@@ -1,5 +1,5 @@
 {
-    "shape": "SPHERE",
+    "shape": "veil:sphere",
     "dimensions": [
         0.5, 0.5, 0.5
     ],

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/test_shape.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/test_shape.json
@@ -1,5 +1,5 @@
 {
-    "shape": "CUBE",
+    "shape": "veil:cube",
     "dimensions": [
         20.0,
         20.0,


### PR DESCRIPTION
# Changes made

This PR adds five new Registries:
- `quasar/emitter_shape`
- `quasar/render_style`
- `quasar/module_type/init`
- `quasar/module_type/update`
- `quasar/module_type/render`

## Emitter Shapes

Before, the Emitter Shapes usable in an `EmitterShapeSettings` were listed in an enum, `EmitterShape.Shape`. This meant that other mods could not add their own emitter shapes. With the registry, this is now possible.

## Render Styles

Render Styles were previously also an enum, `RenderData.RenderStyle`. This has been extracted into an interface, `RenderStyle`, and a registry of these has been made. This allows other mods to add their own render styles, allowing particles to render however they want (e.g. with block models, or with complex custom geometry).

## Particle Modules

`ParticleModuleTypeRegistry` previously held three 'registries' of particle modules (init, update, and render). These were not `Registry<ModuleType<?>>`s, but instead `BiMap<String, ModuleType<?>>`s. Due to this, there was no namespacing of IDs (as `String`s were used instead of `ResourceLocation`s), which could cause name collisions if multiple mods added particle types of the same name.

The BiMaps are now replaced with three `Registry`s.

# Backwards Compatibility

Because Emitter Shapes, Render Styles, and Particle Modules were previously referenced in JSONs by only their names (often capitalised, e.g. `CUBE`), but they now have ResourceLocation names (like `veil:cube`), the Codecs for these thing have backwards compatibility with the old names. Any string given to them, if not already a valid name, is lowercased and given the `veil:` prefix when parsed.

# Questions

## `ParticleModuleTypeRegistry` class location

The `ParticleModuleTypeRegistry` class was in `foundry.veil.api.quasar.data`. I haven't moved it. However, the two new registry classes are in `foundry.veil.api.quasar.registry`. Should I move it there for consistency?

## Forge

When I asked about the use of `BiMap`s rather than `Registry`s in `ParticleModuleTypeRegistry`, i was told it was "[bc we don't have a multiplat registry impl](https://discord.com/channels/1022254439836430386/1087490252874207304/1267996767085924415)". Looking at the Forge impl of `RegistrationProvider`, and seeing that there are some custom `Registry`s already (like `LightTypeRegistry` and `PostPipelineStageRegistry`), I assume this is outdated and that custom `Registry`s will work on either platform.

However, I cannot test this myself, as for some reason I can't get Forge to run on my computer - it complains with this error:
<details>

```
ANTLR Tool version 4.9.1 used for code generation does not match the current runtime version 4.13.1
ANTLR Runtime version 4.9.1 used for parser compilation does not match the current runtime version 4.13.1
Exception in thread "main" java.lang.ExceptionInInitializerError
	at MC-BOOTSTRAP/accesstransformers@8.0.4/net.minecraftforge.accesstransformer.parser.AccessTransformerList.loadFromPath(AccessTransformerList.java:31)
	at MC-BOOTSTRAP/accesstransformers@8.0.4/net.minecraftforge.accesstransformer.AccessTransformerEngine.addResource(AccessTransformerEngine.java:56)
	at MC-BOOTSTRAP/accesstransformers@8.0.4/net.minecraftforge.accesstransformer.service.AccessTransformerService.offerResource(AccessTransformerService.java:22)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.FMLLoader.addAccessTransformer(FMLLoader.java:197)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.LoadingModList.lambda$addAccessTransformers$0(LoadingModList.java:83)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.LoadingModList.lambda$addAccessTransformers$1(LoadingModList.java:83)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.LoadingModList.addAccessTransformers(LoadingModList.java:83)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.moddiscovery.ModValidator.stage2Validation(ModValidator.java:122)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.FMLLoader.completeScan(FMLLoader.java:172)
	at MC-BOOTSTRAP/fmlloader@1.20.1-47.3.1/net.minecraftforge.fml.loading.FMLServiceProvider.completeScan(FMLServiceProvider.java:91)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.TransformationServiceDecorator.onCompleteScan(TransformationServiceDecorator.java:174)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.TransformationServicesHandler.lambda$triggerScanCompletion$24(TransformationServicesHandler.java:145)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.TransformationServicesHandler.triggerScanCompletion(TransformationServicesHandler.java:147)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.Launcher.run(Launcher.java:95)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.Launcher.main(Launcher.java:78)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@10.0.9/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23)
	at cpw.mods.bootstraplauncher@1.1.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:141)
Caused by: java.lang.UnsupportedOperationException: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
	at MC-BOOTSTRAP/org.antlr.antlr4.runtime@4.13.1/org.antlr.v4.runtime.atn.ATNDeserializer.deserialize(ATNDeserializer.java:56)
	at MC-BOOTSTRAP/org.antlr.antlr4.runtime@4.13.1/org.antlr.v4.runtime.atn.ATNDeserializer.deserialize(ATNDeserializer.java:48)
	at MC-BOOTSTRAP/accesstransformers@8.0.4/net.minecraftforge.accesstransformer.generated.AtLexer.<clinit>(AtLexer.java:461)
	... 37 more
Caused by: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
	... 40 more
```

</details>

