### PR TITLE
Discard low-alpha fragments in Quasar Particles

### DIFF
--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.fsh
@@ -14,5 +14,9 @@ in vec4 vertexColor;
 out vec4 fragColor;
 
 void main() {
-    fragColor = linear_fog(texture(Sampler0, texCoord0) * vertexColor * ColorModulator, vertexDistance, FogStart, FogEnd, FogColor);
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    if (color.a < 0.1) {
+        discard;
+    }
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
 }


### PR DESCRIPTION
The shader previously didn't discard nearly-invisible fragments, leading to weird transparency issues.

Before:
![2024-08-03_00 36 08](https://github.com/user-attachments/assets/4eb47978-1c74-49a4-8f37-dd08516b92e5)

After:
![2024-08-03_00 35 33](https://github.com/user-attachments/assets/ad93a228-1a46-47de-b8b3-171c9d6be5a1)

