### PR TITLE
Quasar: Allow Emitter Settings to have multiple shapes

### DIFF
--- a/common/src/main/java/foundry/veil/api/quasar/data/EmitterSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/EmitterSettings.java
@@ -2,20 +2,24 @@ package foundry.veil.api.quasar.data;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.util.CodecUtil;
 import net.minecraft.core.Holder;
+import net.minecraft.util.ExtraCodecs;
 
-public record EmitterSettings(Holder<EmitterShapeSettings> emitterShapeSettingsHolder,
+import java.util.List;
+
+public record EmitterSettings(List<Holder<EmitterShapeSettings>> emitterShapeSettingsHolders,
                               Holder<ParticleSettings> particleSettingsHolder,
                               boolean forceSpawn) {
 
     public static final Codec<EmitterSettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            EmitterShapeSettings.CODEC.fieldOf("shape").forGetter(EmitterSettings::emitterShapeSettingsHolder),
+            CodecUtil.singleOrList(EmitterShapeSettings.CODEC).fieldOf("shape").forGetter(EmitterSettings::emitterShapeSettingsHolders),
             ParticleSettings.CODEC.fieldOf("particle_settings").forGetter(EmitterSettings::particleSettingsHolder),
             Codec.BOOL.optionalFieldOf("force_spawn", false).forGetter(EmitterSettings::forceSpawn)
     ).apply(instance, EmitterSettings::new));
 
-    public EmitterShapeSettings emitterShapeSettings() {
-        return this.emitterShapeSettingsHolder.value();
+    public List<EmitterShapeSettings> emitterShapeSettings() {
+        return this.emitterShapeSettingsHolders.stream().map(Holder::value).toList();
     }
 
     public ParticleSettings particleSettings() {

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleEmitterData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleEmitterData.java
@@ -2,10 +2,13 @@ package foundry.veil.api.quasar.data;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.util.CodecUtil;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.RegistryFileCodec;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * @param maxLifetime

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -60,7 +60,7 @@ public class ParticleEmitter {
     private int rate;
     private int count;
     private int maxParticles;
-    private EmitterShapeSettings emitterShapeSettings;
+    private List<EmitterShapeSettings> emitterShapeSettings;
     private ParticleSettings particleSettings;
     private boolean forceSpawn;
     private QuasarParticleData particleData;
@@ -107,7 +107,7 @@ public class ParticleEmitter {
         this.particleManager.reserve(count);
 
         for (int i = 0; i < count; i++) {
-            Vector3dc particlePos = this.emitterShapeSettings.getPos(this.randomSource, this.position);
+            Vector3dc particlePos = this.emitterShapeSettings.get(i % this.emitterShapeSettings.size()).getPos(this.randomSource, this.position);
             Vector3fc particleDirection = this.particleSettings.particleDirection(this.randomSource);
 
             // TODO
@@ -376,7 +376,7 @@ public class ParticleEmitter {
         return this.maxParticles;
     }
 
-    public EmitterShapeSettings getEmitterShapeSettings() {
+    public List<EmitterShapeSettings> getEmitterShapeSettings() {
         return this.emitterShapeSettings;
     }
 
@@ -449,7 +449,7 @@ public class ParticleEmitter {
         this.maxParticles = maxParticles;
     }
 
-    public void setEmitterShapeSettings(EmitterShapeSettings emitterShapeSettings) {
+    public void setEmitterShapeSettings(List<EmitterShapeSettings> emitterShapeSettings) {
         this.emitterShapeSettings = emitterShapeSettings;
     }
 

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/emitters/double_smoke_rings.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/emitters/double_smoke_rings.json
@@ -1,0 +1,11 @@
+{
+  "max_lifetime": 40,
+  "loop": false,
+  "rate": 1,
+  "count": 16,
+  "emitter_settings": {
+      "shape": ["veil:large_ring", "veil:small_ring"],
+      "particle_settings": "veil:smoke_bigger"
+  },
+  "particle_data": "veil:smoke_big_static"
+}

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/particle/smoke_bigger.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/particle/smoke_bigger.json
@@ -1,0 +1,17 @@
+{
+    "random_speed": false,
+    "random_size": true,
+    "random_lifetime": true,
+    "initial_direction": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "random_initial_direction": false,
+    "random_initial_rotation": false,
+    "particle_size_variation": 0.1,
+    "particle_lifetime": 48,
+    "particle_lifetime_variation": 32.0,
+    "particle_speed": 1.0,
+    "base_particle_size": 5.0
+}

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/large_ring.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/large_ring.json
@@ -1,0 +1,14 @@
+{
+    "shape": "DISC",
+    "dimensions": [
+        2.0,
+        0.01,
+        2.0
+    ],
+    "rotation": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "from_surface": true
+}

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/small_ring.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/emitter/shape/small_ring.json
@@ -1,0 +1,14 @@
+{
+    "shape": "DISC",
+    "dimensions": [
+        1.0,
+        0.01,
+        1.0
+    ],
+    "rotation": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "from_surface": true
+}

--- a/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/particle_data/smoke_big_static.json
+++ b/common/src/main/resources/resourcepacks/test_particles/assets/veil/quasar/modules/particle_data/smoke_big_static.json
@@ -1,0 +1,24 @@
+{
+  "sprite_data": {
+    "sprite": "veil:textures/particle/smoke.png",
+    "frame_count": 64,
+    "frame_width": 8,
+    "frame_height": 8,
+    "stretch_to_lifetime": true
+  },
+  "render_style": "BILLBOARD",
+  "init_modules": [
+    "veil:smoke_random_init_rotation"
+  ],
+  "update_modules": [],
+  "collision_modules": [
+  ],
+  "forces": [
+  ],
+  "render_modules": [
+    "veil:color/smoke_color_over_lifetime"
+  ],
+  "face_velocity": false,
+  "velocity_stretch_factor": 0.0,
+  "should_collide": true
+}


### PR DESCRIPTION
Emitter settings can now have an array of shapes rather than just one.

Supplying just one is still supported.