### PR TITLE
I don't even know why this works

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/registry/RenderTypeShardRegistry.java
+++ b/common/src/main/java/foundry/veil/api/client/registry/RenderTypeShardRegistry.java
@@ -20,8 +20,7 @@ public final class RenderTypeShardRegistry {
 
     private static final Map<String, List<RenderStateShard>> SHARDS = new HashMap<>();
     private static final Set<GenericShard> GENERIC_SHARDS = new HashSet<>();
-    private static final Map<String, RenderType.CompositeRenderType> CREATED_RENDER_TYPES = new WeakHashMap<>();
-
+    private static final Set<RenderType.CompositeRenderType> CREATED_RENDER_TYPES = new HashSet<>();
     private RenderTypeShardRegistry() {
     }
 
@@ -54,7 +53,7 @@ public final class RenderTypeShardRegistry {
         List<RenderStateShard> newShards = Arrays.asList(shards);
         SHARDS.computeIfAbsent(name, unused -> new ArrayList<>()).addAll(newShards);
 
-        for (RenderType.CompositeRenderType renderType : CREATED_RENDER_TYPES.values()) {
+        for (RenderType.CompositeRenderType renderType : CREATED_RENDER_TYPES) {
             if (name.equals(VeilRenderType.getName(renderType))) {
                 ((CompositeStateExtension) (Object) renderType.state()).veil$addShards(newShards);
             }
@@ -73,7 +72,7 @@ public final class RenderTypeShardRegistry {
         }
         GENERIC_SHARDS.add(new GenericShard(filter, shards));
 
-        for (RenderType.CompositeRenderType renderType : CREATED_RENDER_TYPES.values()) {
+        for (RenderType.CompositeRenderType renderType : CREATED_RENDER_TYPES) {
             if (filter.test(renderType)) {
                 ((CompositeStateExtension) (Object) renderType.state()).veil$addShards(Arrays.asList(shards));
             }
@@ -103,7 +102,7 @@ public final class RenderTypeShardRegistry {
         if (shards != null) {
             ((CompositeStateExtension) (Object) renderType.state()).veil$addShards(shards);
         }
-        CREATED_RENDER_TYPES.put(RenderType.CompositeRenderType.class.getName() + "@" + Integer.toHexString(renderType.hashCode()), renderType);
+        CREATED_RENDER_TYPES.add(renderType);
     }
 
     private record GenericShard(Predicate<RenderType.CompositeRenderType> filter, RenderStateShard[] shards) {


### PR DESCRIPTION
There is apparently a bug that only happens every once in a while but was frequent enough for me to want to fix it (Using Fabric btw. No idea if this also happens on neo forge).

When starting up the game, there is a chance that no block data is sent to any of the main dynamic buffers (first person buffers and depths worked fine). When shaders try to use these framebuffers, it would return 0 for any buffer.

Normal:
<img width="2033" height="1244" alt="Screenshot 2025-09-10 223437" src="https://github.com/user-attachments/assets/8cef827d-2afa-4cbe-bc0a-b5b81fe7b9e6" />

Every once in a while:
<img width="2034" height="1261" alt="Screenshot 2025-09-10 224349" src="https://github.com/user-attachments/assets/c0f35d81-3118-4beb-bc80-e92088c0aaba" />

The only way I found to solve this was to restart the game.

I looked through veil's commits one by one and am 90% sure that the changes to the RenderTypeShardRegistry [here](https://github.com/FoundryMC/Veil/commit/cf6ca02f07f371c3bcbbf7e0e60be0da1aa7135d#diff-47521cdce86a952ee54e13c78e5cc0c391407f474061e0cca61c2e77a54a6243R24) were the cause of the issue.
For some reason reverting this file seems to fix it

~~I can't say for SURE if this works because the only way I've been testing it was opening Minecraft, seeing if the bug was there, closing and repeating until the bug occurred.~~ So far with this fix it hasn't happened

I'm not gonna pretend to know why it works. If you have any theories, Id love to learn.

Edit: I've been using this build for a while now, and have never encountered the issue since

Edit2: A friend of mine also had the bug and using this build also fixed it for them

Edit3: pretty sure this would close issue #80 