### PR TITLE
Quotes or Angle Brackets in #includes in shaders

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/render/shader/processor/ShaderImportProcessor.java
+++ b/common/src/main/java/foundry/veil/api/client/render/shader/processor/ShaderImportProcessor.java
@@ -30,6 +30,11 @@ public class ShaderImportProcessor implements ShaderPreProcessor {
         }
         for (String directive : imports) {
             String importId = directive.substring(ShaderImportProcessor.INCLUDE_KEY.length()).trim();
+
+            if ((importId.startsWith("\"") && importId.endsWith("\"")) || (importId.startsWith("<") && importId.endsWith(">"))) {
+                importId = importId.substring(1, importId.length() - 1);
+            }
+
             try {
                 ctx.include(tree, ResourceLocation.parse(importId), IncludeOverloadStrategy.SOURCE);
             } catch (ResourceLocationException e) {


### PR DESCRIPTION
I use a glsl syntax highlighting plugin for IntelliJ, and when you have imports formatted like this: `#include veil:common`, that gives an error, and the rest of the file isn't styled. So this is just a little thing that allows people to do `#include "veil:common"` instead, which isn't an error, and now we have syntax highlighting again (yay!)