### PR TITLE
LayeredRenderType#draw fix and general Flare fixes

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/property/InvertibleProperty.java
+++ b/common/src/main/java/foundry/veil/api/client/property/InvertibleProperty.java
@@ -4,6 +4,7 @@ import foundry.veil.api.client.registry.PropertyRegistry;
 import foundry.veil.api.flare.modifier.PropertyModifier;
 import gg.moonflower.molangcompiler.api.MolangExpression;
 import net.minecraft.client.renderer.ShaderInstance;
+import org.jetbrains.annotations.Contract;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,16 +22,24 @@ public abstract class InvertibleProperty<T> extends Property<T> {
 
     public InvertibleProperty(PropertyRegistry.PropertyType<T, ?> type, T value) {
         super(type, value);
-        this.inverseValue = this.calculateInverse(this.cloneValue(value));
-        this.overrideInverseValue = this.cloneValue(value);
+        this.inverseValue = this.invertAndMutate(this.cloneValue(value));
+        this.overrideInverseValue = this.cloneValue(inverseValue);
     }
 
-    protected abstract T calculateInverse(T value);
+    @SuppressWarnings("UnstableApiUsage")
+    @Contract(mutates = "param")
+    protected abstract T invertAndMutate(T value);
 
     @Override
     public final void modify(T value, PropertyModifier.PropertyModifierMode mode, Optional<List<MolangExpression>> optionalMolang) {
         this.modifyPreInvert(value, mode, optionalMolang);
-        this.overrideInverseValue = this.calculateInverse(value);
+        
+        T originalOverrideValue = this.overrideValue;
+        this.overrideValue = overrideInverseValue;
+        this.modifyPreInvert(originalOverrideValue, PropertyModifier.PropertyModifierMode.REPLACE, Optional.empty());
+        this.overrideValue = originalOverrideValue;
+        
+        this.invertAndMutate(this.overrideInverseValue);
     }
 
     public abstract void modifyPreInvert(T value, PropertyModifier.PropertyModifierMode mode, Optional<List<MolangExpression>> optionalMolang);
@@ -44,7 +53,10 @@ public abstract class InvertibleProperty<T> extends Property<T> {
 
     @Override
     public void resetOverrideValue() {
-        super.resetOverrideValue();
-        this.overrideInverseValue = this.inverseValue;
+        this.modifyPreInvert(this.value, PropertyModifier.PropertyModifierMode.REPLACE, Optional.empty());
+        T originalOverrideValue = this.overrideValue;
+        this.overrideValue = overrideInverseValue;
+        this.modifyPreInvert(this.inverseValue, PropertyModifier.PropertyModifierMode.REPLACE, Optional.empty());
+        this.overrideValue = originalOverrideValue;
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/property/Property.java
+++ b/common/src/main/java/foundry/veil/api/client/property/Property.java
@@ -50,7 +50,7 @@ public abstract class Property<T> {
     protected abstract T cloneValue(T value);
 
     public void resetOverrideValue() {
-        this.overrideValue = this.cloneValue(this.value);
+        this.modify(this.value, PropertyModifier.PropertyModifierMode.REPLACE, Optional.empty());
     }
 
     public PropertyRegistry.PropertyType<T, ? extends Property<T>> getType() {

--- a/common/src/main/java/foundry/veil/api/client/property/model/RotationModelProperty.java
+++ b/common/src/main/java/foundry/veil/api/client/property/model/RotationModelProperty.java
@@ -21,11 +21,12 @@ import java.util.Optional;
 @InapplicableProperty
 public class RotationModelProperty extends Vec3ModelProperty {
     private final Quaternionfc rotation;
-    private final Quaternionf overrideRotation = new Quaternionf();
+    private final Quaternionf overrideRotation;
 
     public RotationModelProperty(Vector3f value) {
         super(value);
-        rotation =  new Quaternionf().rotationXYZ(value.x() * Mth.DEG_TO_RAD, value.y() * Mth.DEG_TO_RAD, value.z() * Mth.DEG_TO_RAD);
+        this.rotation = new Quaternionf().rotationXYZ(value.x() * Mth.DEG_TO_RAD, value.y() * Mth.DEG_TO_RAD, value.z() * Mth.DEG_TO_RAD);
+        this.overrideRotation = new Quaternionf(this.rotation);
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/api/client/property/properties/Mat3Property.java
+++ b/common/src/main/java/foundry/veil/api/client/property/properties/Mat3Property.java
@@ -7,6 +7,7 @@ import foundry.veil.api.flare.modifier.PropertyModifier;
 import gg.moonflower.molangcompiler.api.MolangExpression;
 import gg.moonflower.molangcompiler.api.MolangRuntime;
 import net.minecraft.client.renderer.ShaderInstance;
+import org.jetbrains.annotations.Contract;
 import org.joml.Matrix3f;
 import org.joml.Matrix3fc;
 
@@ -46,9 +47,11 @@ public class Mat3Property extends InvertibleProperty<Matrix3f> {
     protected Matrix3f cloneValue(Matrix3f value) {
         return new Matrix3f(value);
     }
-
+    
+    @SuppressWarnings("UnstableApiUsage")
+    @Contract(mutates = "param")
     @Override
-    protected Matrix3f calculateInverse(Matrix3f value) {
+    protected Matrix3f invertAndMutate(Matrix3f value) {
         return value.invert();
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/property/properties/Mat4Property.java
+++ b/common/src/main/java/foundry/veil/api/client/property/properties/Mat4Property.java
@@ -7,6 +7,7 @@ import foundry.veil.api.flare.modifier.PropertyModifier;
 import gg.moonflower.molangcompiler.api.MolangExpression;
 import gg.moonflower.molangcompiler.api.MolangRuntime;
 import net.minecraft.client.renderer.ShaderInstance;
+import org.jetbrains.annotations.Contract;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 
@@ -46,9 +47,11 @@ public class Mat4Property extends InvertibleProperty<Matrix4f> {
     protected Matrix4f cloneValue(Matrix4f value) {
         return new Matrix4f(value);
     }
-
+    
+    @SuppressWarnings("UnstableApiUsage")
+    @Contract(mutates = "param")
     @Override
-    protected Matrix4f calculateInverse(Matrix4f value) {
+    protected Matrix4f invertAndMutate(Matrix4f value) {
         return value.invert();
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/property/properties/Sampler2DProperty.java
+++ b/common/src/main/java/foundry/veil/api/client/property/properties/Sampler2DProperty.java
@@ -20,13 +20,13 @@ public class Sampler2DProperty extends Property<AbstractTexture> {
     public static final MapCodec<Sampler2DProperty> CODEC = ResourceLocation.CODEC.fieldOf("value").xmap(Sampler2DProperty::new, property -> property.source);
 
     public Sampler2DProperty(ResourceLocation value) {
-        super(PropertyRegistry.SAMPLER2D.get(), Minecraft.getInstance().getTextureManager().getTexture(value));
+        super(PropertyRegistry.SAMPLER2D.get(), null);
         this.source = value;
     }
 
     @Override
     public void applyValue(String name, ShaderInstance shader) {
-        shader.setSampler(name, this.overrideValue.getId());
+        shader.setSampler(name, Minecraft.getInstance().getTextureManager().getTexture(source).getId());
         // Shader must be re-applied for the sampler to take effect
         shader.apply();
     }

--- a/common/src/main/java/foundry/veil/api/client/property/properties/TimeProperty.java
+++ b/common/src/main/java/foundry/veil/api/client/property/properties/TimeProperty.java
@@ -34,8 +34,8 @@ public class TimeProperty extends Property<Vector4f> {
     public void applyValue(String name, ShaderInstance shader) {
         Uniform uniform = shader.getUniform(name);
         if (uniform != null) {
-            float time = Minecraft.getInstance().getFrameTimeNs() * 1e-9f;
-            uniform.set(this.value.set(time / 20.0f, time, 2.0f * time, Mth.sin(time)));
+            float time = System.nanoTime() * 1e-9f;
+            uniform.set(this.value.set(time / 20.0f, time, 2.0f * time, Mth.sin(time % Mth.TWO_PI)));
         }
     }
 

--- a/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
+++ b/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
@@ -281,15 +281,15 @@ public final class VeilRenderType extends RenderType {
         public void draw(@NotNull MeshData meshData) {
             super.draw(meshData);
             if (BufferUploader.lastImmediateBuffer != null) {
-                ShaderInstance shader = RenderSystem.getShader();
-                if (shader == null) {
-                    return;
-                }
 
                 Matrix4f modelViewMatrix = RenderSystem.getModelViewMatrix();
                 Matrix4f projectionMatrix = RenderSystem.getProjectionMatrix();
                 for (RenderType layer : this.layers) {
                     layer.setupRenderState();
+                    ShaderInstance shader = RenderSystem.getShader();
+                    if (shader == null) {
+                        return;
+                    }
                     BufferUploader.lastImmediateBuffer.drawWithShader(modelViewMatrix, projectionMatrix, shader);
                     layer.clearRenderState();
                 }

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareEffectLayer.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareEffectLayer.java
@@ -77,7 +77,10 @@ public class FlareEffectLayer {
         }
 
         ControllerManager controllerManager = FlareEffectManager.getInstance().getControllerManager();
-        for (PropertyModifier<?> modifier : this.originalModifiers) {
+        
+        List<PropertyModifier<?>> size = this.originalModifiers;
+        for (int i = 0, propertyModifiersSize = size.size(); i < propertyModifiersSize; i++) {
+            PropertyModifier<?> modifier = size.get(i);
             controllerManager.getOrCreateController(modifier.inputControllerName(), host).update(partialTick);
         }
 

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareEffectTemplate.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareEffectTemplate.java
@@ -33,7 +33,9 @@ public final class FlareEffectTemplate {
     }
     
     public void render(EffectHost host, MatrixStack matrixStack, float partialTick, @Nullable Map<ResourceLocation, BakedShell> shellOverrides) {
-        for (FlareEffectLayer effectLayer : this.effectLayers) {
+        List<FlareEffectLayer> layers = this.effectLayers;
+        for (int i = 0, size = layers.size(); i < size; i++) {
+            FlareEffectLayer effectLayer = layers.get(i);
             effectLayer.render(host, matrixStack, partialTick, shellOverrides);
         }
     }

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareMaterial.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareMaterial.java
@@ -17,6 +17,7 @@ import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public final class FlareMaterial {
         this.clazz = clazz;
         this.renderTypeLocation = renderTypeLocation;
         this.randomizeSeed = randomizeSeed;
-        this.properties = Map.copyOf(properties);
+        this.properties = new HashMap<>(properties);
     }
     
     public void applyProperties(EffectHost host, @Nullable ShaderInstance shader, Map<String, List<PropertyModifier<?>>> modifiers) {

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareMaterial.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareMaterial.java
@@ -13,11 +13,11 @@ import foundry.veil.api.flare.EffectHost;
 import foundry.veil.api.flare.modifier.PropertyModifier;
 import foundry.veil.api.util.CodecUtil;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +41,8 @@ public final class FlareMaterial {
     private final String clazz;
     private final ResourceLocation renderTypeLocation;
     private final boolean randomizeSeed;
-    private final Map<String, Property<?>> properties;
+    private final Object2ObjectArrayMap<String, Property<?>> properties;
+    private final List<Object2ObjectMap.Entry<String, Property<?>>> propertyEntries;
     
     
     public FlareMaterial(String clazz, ResourceLocation renderTypeLocation, boolean randomizeSeed, Map<String, Property<?>> properties) {
@@ -52,14 +53,17 @@ public final class FlareMaterial {
         this.clazz = clazz;
         this.renderTypeLocation = renderTypeLocation;
         this.randomizeSeed = randomizeSeed;
-        this.properties = new HashMap<>(properties);
+        this.properties = new Object2ObjectArrayMap<>(properties);
+        this.propertyEntries = this.properties.object2ObjectEntrySet().stream().toList();
     }
     
     public void applyProperties(EffectHost host, @Nullable ShaderInstance shader, Map<String, List<PropertyModifier<?>>> modifiers) {
         if (shader == null) {
             return;
         }
-        for (Map.Entry<String, Property<?>> entry : this.properties.entrySet()) {
+        List<Object2ObjectMap.Entry<String, Property<?>>> entries = this.propertyEntries;
+        for (int i = 0, size = entries.size(); i < size; i++) {
+            Map.Entry<String, Property<?>> entry = entries.get(i);
             Property<?> property = entry.getValue();
             Class<?> propertyClass = property.getClass();
             
@@ -83,7 +87,10 @@ public final class FlareMaterial {
         if (shader == null) {
             return;
         }
-        for (Property<?> property : this.properties.values()) {
+        List<Object2ObjectMap.Entry<String, Property<?>>> entries = this.propertyEntries;
+        for (int i = 0, size = entries.size(); i < size; i++) {
+            Object2ObjectMap.Entry<String, Property<?>> entry = entries.get(i);
+            Property<?> property = entry.getValue();
             if (property.getClass().getAnnotation(ModelProperty.class) != null) {
                 continue;
             }

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareModel.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareModel.java
@@ -20,10 +20,7 @@ import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Matrix4f;
-import org.joml.Matrix4fStack;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
 
 import java.util.List;
 import java.util.Map;
@@ -41,8 +38,9 @@ public class FlareModel {
             CodecUtil.VECTOR3FC_CODEC.fieldOf("scaleOffset").forGetter(FlareModel::getScaleOffset),
             CodecUtil.singleOrList(FlareMaterial.CODEC).fieldOf("materials").forGetter(FlareModel::getMaterials)
     ).apply(instance, FlareModel::new));
-
-    public static final Matrix4f dummyMatrix = new Matrix4f();
+    
+    public static final Matrix4f MODEL_TO_LOCAL_MATRIX = new Matrix4f();
+    public static final Matrix4f MATRIX4F = new Matrix4f();
 
     public static final String POSITION_PROPERTY_NAME = "model::position";
     public static final String ROTATION_PROPERTY_NAME = "model::rotation";
@@ -66,29 +64,31 @@ public class FlareModel {
 
     public void render(EffectHost host, MatrixStack matrixStack, Map<String, List<PropertyModifier<?>>> modifiers, @Nullable Map<ResourceLocation, BakedShell> shellOverrides) {
         Vector3fc positionOffset = this.positionOffset.getValue();
+        Quaternionfc rotationOffset = this.rotationOffset.getRotation();
         Vector3fc scaleOffset = this.scaleOffset.getValue();
-
-        matrixStack.matrixPush();
-        matrixStack.translate(positionOffset.x(), positionOffset.y(), positionOffset.z());
-        matrixStack.rotate(this.rotationOffset.getRotation());
-        matrixStack.applyScale(scaleOffset.x(), scaleOffset.y(), scaleOffset.z());
+        
+        MODEL_TO_LOCAL_MATRIX.set(matrixStack.position());
+        MODEL_TO_LOCAL_MATRIX.translate(positionOffset.x(), positionOffset.y(), positionOffset.z());
+        MODEL_TO_LOCAL_MATRIX.rotate(rotationOffset);
+        MODEL_TO_LOCAL_MATRIX.scale(scaleOffset.x(), scaleOffset.y(), scaleOffset.z());
+        
+        BakedShell bakedShell = (shellOverrides != null && shellOverrides.containsKey(this.shell)) ?
+                shellOverrides.get(this.shell) :
+                FlareEffectManager.getInstance().getBakedShell(this.shell);
+        
         Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
-
+        
         this.modelToWorld.modify(
-                matrixStack.position().translateLocal((float) cameraPos.x, (float) cameraPos.y, (float) cameraPos.z, dummyMatrix),
+                MODEL_TO_LOCAL_MATRIX.translate((float) cameraPos.x, (float) cameraPos.y, (float) cameraPos.z, MATRIX4F),
                 PropertyModifier.PropertyModifierMode.REPLACE,
                 Optional.empty()
         );
 
-        BakedShell bakedShell = (shellOverrides != null && shellOverrides.containsKey(this.shell)) ?
-                shellOverrides.get(this.shell) :
-                FlareEffectManager.getInstance().getBakedShell(this.shell);
-
-        Matrix4fStack stack = RenderSystem.getModelViewStack();
-        stack.pushMatrix();
-        stack.mul(matrixStack.position());
+        Matrix4fStack modelViewStack = RenderSystem.getModelViewStack();
+        MATRIX4F.set(modelViewStack);
+        modelViewStack.mul(MODEL_TO_LOCAL_MATRIX);
         RenderSystem.applyModelViewMatrix();
-
+        
         VertexArray vertexArray = bakedShell.getVertexArray();
         vertexArray.bind();
         for (FlareMaterial material : this.materials) {
@@ -100,9 +100,8 @@ public class FlareModel {
             this.draw(renderType, vertexArray, host, material, modifiers);
         }
         VertexArray.unbind();
-        matrixStack.matrixPop();
-
-        stack.popMatrix();
+        
+        modelViewStack.set(MATRIX4F);
         RenderSystem.applyModelViewMatrix();
     }
 

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareModel.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareModel.java
@@ -91,12 +91,15 @@ public class FlareModel {
         
         VertexArray vertexArray = bakedShell.getVertexArray();
         vertexArray.bind();
-        for (FlareMaterial material : this.materials) {
+        
+        List<FlareMaterial> flareMaterials = this.materials;
+        for (int i = 0, size = flareMaterials.size(); i < size; i++) {
+            FlareMaterial material = flareMaterials.get(i);
             RenderType renderType = VeilRenderType.get(material.renderTypeLocation());
             if (renderType == null) {
                 continue;
             }
-
+            
             this.draw(renderType, vertexArray, host, material, modifiers);
         }
         VertexArray.unbind();
@@ -122,7 +125,9 @@ public class FlareModel {
         vertexArray.clear(renderType);
 
         if (renderType instanceof VeilRenderType.LayeredRenderType layeredRenderType) {
-            for (RenderType layer : layeredRenderType.getLayers()) {
+            List<RenderType> layers = layeredRenderType.getLayers();
+            for (int i = 0, size = layers.size(); i < size; i++) {
+                RenderType layer = layers.get(i);
                 vertexArray.setup(layer);
                 currentShader = RenderSystem.getShader();
                 material.applyProperties(host, currentShader, modifiers);

--- a/common/src/main/java/foundry/veil/api/flare/data/effect/FlareSubModule.java
+++ b/common/src/main/java/foundry/veil/api/flare/data/effect/FlareSubModule.java
@@ -37,7 +37,9 @@ public final class FlareSubModule {
     }
     
     public void render(EffectHost host, MatrixStack matrixStack, float partialTick, @Nullable Map<ResourceLocation, BakedShell> shellOverrides) {
-        for (ResourceLocation templateLocation : this.templates) {
+        List<ResourceLocation> resourceLocations = this.templates;
+        for (int i = 0, size = resourceLocations.size(); i < size; i++) {
+            ResourceLocation templateLocation = resourceLocations.get(i);
             FlareEffectTemplate template = FlareEffectManager.getTemplate(templateLocation);
             if (template == null) {
                 LOGGER.error("Template {} could not be found!", templateLocation);

--- a/common/src/main/java/foundry/veil/api/flare/model/ShellBakery.java
+++ b/common/src/main/java/foundry/veil/api/flare/model/ShellBakery.java
@@ -60,7 +60,7 @@ public final class ShellBakery {
     }
 
     private static float[] makeVertices(ShellFaceUV uvs, Vector3f normal, Direction direction, float[] posDiv16, @Nullable ShellElementRotation rotation) {
-        float[] vertexData = new float[20];
+        float[] vertexData = new float[32];
         Matrix4f rotationMatrix = null;
         if (rotation != null) {
             float angle = rotation.angle() * Mth.DEG_TO_RAD;
@@ -103,12 +103,12 @@ public final class ShellBakery {
     }
 
     private static void fillVertex(float[] vertexData, int vertexIndex, Vector3f pos, Vector3f normal, ShellFaceUV shellFaceUV) {
-        int i = vertexIndex * 5;
+        int i = vertexIndex * 8;
         vertexData[i] = pos.x();
         vertexData[i + 1] = pos.y();
         vertexData[i + 2] = pos.z();
-        vertexData[i + 3] = normal.z();
-        vertexData[i + 4] = normal.z();
+        vertexData[i + 3] = normal.x();
+        vertexData[i + 4] = normal.y();
         vertexData[i + 5] = normal.z();
         vertexData[i + 6] = shellFaceUV.getU(vertexIndex) / 16.0F;
         vertexData[i + 7] = shellFaceUV.getV(vertexIndex) / 16.0F;

--- a/common/src/main/java/foundry/veil/api/flare/modifier/PropertyModifier.java
+++ b/common/src/main/java/foundry/veil/api/flare/modifier/PropertyModifier.java
@@ -128,7 +128,7 @@ public abstract class PropertyModifier<T> {
             return;
         }
         for (PropertyModifier<?> modifier : modifiers) {
-            if (clazz != null && !Objects.equals(clazz, modifier.clazz)) {
+            if (clazz != null && modifier.clazz != null && !modifier.clazz.equals(clazz)) {
                 continue;
             }
             modifier.apply(host, property);

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/flare/templates/plume.json
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/flare/templates/plume.json
@@ -3,7 +3,7 @@
     "name": "plume",
     "model": {
       "path": "veil:cylinder",
-      "positionOffset": [0, -9, 0],
+      "positionOffset": [0, 0, 0],
       "rotationOffset": [0, 0, 0],
       "scaleOffset": [2, 2, 2],
       "materials": {
@@ -106,8 +106,8 @@
           ],
           [
             {"time": 0.0, "value": 0.0, "easing": "ease_in_quad"},
-            {"time": 0.05, "value": 1.8, "easing": "ease_out_quad"},
-            {"time": 1.0, "value": 9.0, "easing": "linear"}
+            {"time": 0.05, "value": 0.0, "easing": "ease_out_quad"},
+            {"time": 1.0, "value": 0.0, "easing": "linear"}
           ],
           [
             {"time": 0.0, "value": 0.0, "easing": "linear"},

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/flare/templates/splash.json
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/flare/templates/splash.json
@@ -47,9 +47,9 @@
             [
               {"time": 0.0, "value": 0.0, "easing": "ease_in_quad"},
               {"time": 0.5, "value": 1.5, "easing": "ease_in_quad"},
-              {"time": 0.75, "value": 1.25, "easing": "ease_in_quad"},
-              {"time": 0.8, "value": 1.0, "easing": "ease_in_quad"},
-              {"time": 1.0, "value": 0.0, "easing": "ease_in_quad"}
+              {"time": 0.6, "value": 1.5, "easing": "ease_in_quad"},
+              {"time": 0.8, "value": 0.75, "easing": "ease_out_quad"},
+              {"time": 0.9, "value": 0.0, "easing": "ease_in_quad"}
             ],
             [
               {"time": 0.0, "value": 1.0, "easing": "ease_out_quad"}

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/rendertypes/flare/splash.json
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/rendertypes/flare/splash.json
@@ -21,11 +21,11 @@
     {
       "type": "minecraft:write_mask",
       "color": true,
-      "depth": false
+      "depth": true
     },
     {
       "type": "minecraft:cull",
-      "face": "none"
+      "face": "back"
     }
   ]
 }

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/base.vsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/base.vsh
@@ -1,22 +1,30 @@
+
+uniform mat4 ModelToWorld;
+uniform mat4 IModelToWorld;
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform mat3 NormalMat;
+uniform mat3 IViewMat;
+
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec4 Color;
 layout(location = 2) in vec2 UV0;
 layout(location = 3) in vec2 UV2;
 layout(location = 4) in vec3 Normal;
 
-uniform mat4 ModelViewMat;
-uniform mat4 ProjMat;
-uniform mat3 NormalMat;
-
 out vec2 texCoord0;
 out vec4 vertexColor;
 out vec3 vertexNormal;
 
+out vec2 texCoord1;
+
 void main() {
-    vec4 pos = ModelViewMat * vec4(Position, 1.0);
-    gl_Position = ProjMat * pos;
+    vec4 pos = vec4(Position, 1.0);
+    gl_Position = ProjMat * ModelViewMat * pos;
 
     vertexNormal = Normal;
     texCoord0 = UV0;
+    texCoord1 = UV0;
+    texCoord1.x += fract(5.0*Normal.x+3.1415926535*Normal.z);
     vertexColor = Color;
 }

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/base.vsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/base.vsh
@@ -3,8 +3,6 @@ uniform mat4 ModelToWorld;
 uniform mat4 IModelToWorld;
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
-uniform mat3 NormalMat;
-uniform mat3 IViewMat;
 
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec4 Color;

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/plume.fsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/plume.fsh
@@ -10,11 +10,14 @@ in vec2 texCoord0;
 in vec4 vertexColor;
 in vec3 vertexNormal;
 
+in vec2 texCoord1;
+
 out vec4 fragColor;
 
 void main() {
-    float uvTime = _Time.x * Speed * 1000.0;
+    float uvTime = _Time.y * Speed;
     fragColor = vec4(texCoord0.y * 0.5 / (1.0 - texCoord0.y)) * ColorMultiplier;
-    fragColor *= texture(Noise, vec2(texCoord0.x * 0.5 * ColorMultiplier.a,texCoord0.y * 0.1 + uvTime)).a;
+//    fragColor *= texture(Noise, vec2(texCoord1.x * 0.5 * ColorMultiplier.a,texCoord0.y * 0.1 + uvTime)).a;
+    fragColor *= texture(Noise, vec2(texCoord1.x * 0.5 * ColorMultiplier.a, texCoord1.y * 0.041 + uvTime)).a;
 }
 

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/plume.fsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/plume.fsh
@@ -17,7 +17,6 @@ out vec4 fragColor;
 void main() {
     float uvTime = _Time.y * Speed;
     fragColor = vec4(texCoord0.y * 0.5 / (1.0 - texCoord0.y)) * ColorMultiplier;
-//    fragColor *= texture(Noise, vec2(texCoord1.x * 0.5 * ColorMultiplier.a,texCoord0.y * 0.1 + uvTime)).a;
     fragColor *= texture(Noise, vec2(texCoord1.x * 0.5 * ColorMultiplier.a, texCoord1.y * 0.041 + uvTime)).a;
 }
 

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/rainbow.fsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/rainbow.fsh
@@ -17,6 +17,4 @@ void main() {
     float cosT = cos(time - 10.0 * texCoord0.y);
     float sinT = sin(time - 10.0 * texCoord0.y);
     fragColor = vec4(1+cosT, 1.0 + sinT*cosT, 1.0+sinT, texCoord0.y * 0.1 / (1.0 - texCoord0.y)) * ColorMultiplier;
-//    fragColor = vec4(1.0, 1.0, 1.0, 1.0) * ColorMultiplier;
-//    fragColor *= 1 - texCoord0.y;
 }

--- a/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/splash.fsh
+++ b/common/src/main/resources/resourcepacks/test_effects/assets/veil/pinwheel/shaders/program/flare/splash.fsh
@@ -13,12 +13,12 @@ in vec3 vertexNormal;
 out vec4 fragColor;
 
 void main() {
-    float edginess = (1.0 - abs((texCoord0.x + Time) * 2.0 - (1.0 + Time)) / 2.0) + texCoord0.y;
+    float edginess = (1.0 - abs((texCoord0.x + 2.0*Time) * 2.0 - (1.0 + 2.0*Time)) / 2.0) + texCoord0.y;
     fragColor = texture(Sampler0, vec2(texCoord0.x, (texCoord0.y * Shift) / 32 ));
     fragColor *= 1.0 - fragColor.a;
-    fragColor *= texCoord0.y * 0.125 / (1.05 - texCoord0.y);
+    fragColor *= min(texCoord0.y * 0.125 / (0.525 - 0.5*texCoord0.y), 2.0);
     fragColor.rgb *= Blue;
-    fragColor *= edginess * edginess;
-    if (fragColor.a < 0.1) discard;
+    fragColor *= edginess;
+    if (fragColor.a < 0.01) discard;
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=2.5.2
+version=2.5.2-local
 group=foundry.veil
 java_version=21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=2.5.2-local
+version=2.5.2
 group=foundry.veil
 java_version=21
 


### PR DESCRIPTION
LayeredRenderType#draw fix and Flare fixes and performance optimizations.

Fixes:
- LayeredRenderType#draw using the defaultValue's shader for all layers.
- Flare crashing due to incorrect array size.
- Flare creating tons of Iterator objects causing massive memory allocations.