### PR TITLE
Fix typo in docs

### DIFF
--- a/wiki/Animations.md
+++ b/wiki/Animations.md
@@ -4,7 +4,7 @@ populates the frames between keyframes using the easing methods defined when cre
 
 ## Keyframes
 
-Keyframs are the core to Veil's animation system, even though they are extremely simple. Keyframes require a Position (
+Keyframes are the core to Veil's animation system, even though they are extremely simple. Keyframes require a Position (
 Vec3), Rotation (Vec3), Scale (Vec3), Duration (in ticks) and an Easing.
 
 ## Paths


### PR DESCRIPTION
I found a small typo in the wiki and fixed it. I don't think adding one letter (in the docs of all places) is worth its own branch so I took the liberty to make the change on the main 1.21 branch.