### PR TITLE
Fix a_VeilNormal type casting and signed decoding in SodiumShaderPreProcessor

### DIFF
--- a/common/src/main/java/foundry/veil/impl/compat/sodium/SodiumShaderPreProcessor.java
+++ b/common/src/main/java/foundry/veil/impl/compat/sodium/SodiumShaderPreProcessor.java
@@ -68,7 +68,7 @@ public class SodiumShaderPreProcessor implements ShaderPreProcessor {
                             treeBody.add(GlslInjectionPoint.BEFORE_MAIN, GlslParser.parseExpression("uniform mat3 VeilNormalMatrix"));
                         }
                         treeBody.add(GlslInjectionPoint.BEFORE_MAIN, GlslParser.parseExpression("out vec3 PassVeilNormal"));
-                        mainBody.add(GlslParser.parseExpression("PassVeilNormal = %s * %s".formatted(iris ? "iris_NormalMatrix" : "VeilNormalMatrix", iris ? "iris_Normal" : "vec3(a_VeilNormal.xyz * vec3(0.007874016))")));
+                        mainBody.add(GlslParser.parseExpression("PassVeilNormal = %s * %s".formatted(iris ? "iris_NormalMatrix" : "VeilNormalMatrix", iris ? "iris_Normal" : "(vec3(ivec3(a_VeilNormal.xyz)) * 0.007874016)")));
                         modified = true;
                     }
 


### PR DESCRIPTION
### Description
In version 4.1.1, the vertex attribute format for `NORMAL_INDEX` was updated to an un-normalized integer (`normalized = false, isInteger = true`), and the shader input was changed to `uvec4 a_VeilNormal`.

However, the injected expression for calculating `PassVeilNormal` introduced a critical bug:
```glsl
vec3(a_VeilNormal.xyz * vec3(0.007874016))
```
This causes two major issues in core GLSL profiles:

Type Mismatch / Compilation Error: It attempts to multiply a_VeilNormal.xyz (which evaluates to a uvec3) directly with a vec3 float without an explicit cast. This leads to compilation failures or undefined black geometry on various GPU drivers.

Loss of Signed Bits: Since the format encodes signed bytes (-128 to 127) but the shader receives them as an unsigned integer (uvec4), any negative normal direction becomes a huge positive number (due to two's complement), breaking the normal vector direction completely.

### Fix
This PR wraps a_VeilNormal.xyz into an ivec3 first to correctly re-interpret the signed two's complement bits, and then casts it to vec3 before multiplying by 0.007874016 ($1 / 127$).
```glsl
vec3(ivec3(a_VeilNormal.xyz)) * 0.007874016
```
This properly restores the accurate signed -1.0 to 1.0 normal range while preserving the VBO compression optimization made in 4.1.1.