### PR TITLE
Fix memory leak with Quasar particles

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/render/CachedBufferSource.java
+++ b/common/src/main/java/foundry/veil/api/client/render/CachedBufferSource.java
@@ -23,7 +23,7 @@ public class CachedBufferSource implements MultiBufferSource, NativeResource {
     private RenderType lastSharedType;
 
     private void clearBuffers() {
-        this.buffers.values().forEach(ByteBufferBuilder::clear);
+        this.buffers.values().forEach(ByteBufferBuilder::close);
         this.buffers.clear();
     }
 


### PR DESCRIPTION
Closes #111 
`CachedBufferSource` uses `ByteBufferBuilder::clear` instead of `ByteBufferBuilder::close` in `clearBuffers`, and does not free the memory allocated, leading to a memory leak. Calling the correct method appears to (in my testing) fix this issue.
If there are any issues, let me know!