### PR TITLE
Fix Quasar light module having 0 radius with rgb_points

### DIFF
--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
@@ -46,6 +46,10 @@ public class DynamicLightModule implements UpdateParticleModule, RenderParticleM
             this.renderColor.set(this.color);
         }
 
+        if (this.constantRadius) {
+            this.radius = data.radius().getConstant();
+        }
+        
         this.light.setBrightness(this.brightness * this.renderColor.alpha());
         this.light.setRadius(this.radius);
         this.light.setColor(this.color);

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
@@ -85,7 +85,6 @@ public class DynamicLightModule implements UpdateParticleModule, RenderParticleM
         if (this.lightHandle == null) {
             this.lightHandle = VeilRenderSystem.renderer().getLightRenderer().addLight(this.light);
         }
-        this.lastBrightness = brightness;
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java
@@ -46,8 +46,14 @@ public class DynamicLightModule implements UpdateParticleModule, RenderParticleM
             this.renderColor.set(this.color);
         }
 
+        if (this.constantBrightness) {
+            this.brightness = data.brightness().getConstant();
+            this.lastBrightness = this.brightness;
+        }
+
         if (this.constantRadius) {
             this.radius = data.radius().getConstant();
+            this.lastRadius = this.radius;
         }
         
         this.light.setBrightness(this.brightness * this.renderColor.alpha());


### PR DESCRIPTION
Closes #74 
As per the bug report, if the color gradient or the brightness is not constant but the radius is, it will never be initialized in the constructor and be always zero. The same thing applies to the brightness if either of the other two are not constant. This PR fixes these issues by properly applying the brightness and radius in the constructor if either are constant. I also removed setting the `lastBrightness` value at the end of `update()`, as that seemed to cause some flickering. Feel free to let me know if there are any issues!