### PR TITLE
Improve trails module

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
+++ b/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
@@ -97,6 +97,10 @@ public final class VeilRenderType extends RenderType {
         return QUASAR_PARTICLE.apply(texture, additive);
     }
 
+    public static RenderType quasarTrail(@Nullable ResourceLocation texture) {
+        return quasarTrail(texture, true);
+    }
+
     public static RenderType quasarTrail(@Nullable ResourceLocation texture, boolean additive) {
         return texture != null ? QUASAR_TRAIL.apply(texture, additive) : NO_TEXTURE_QUASAR_TRAIL.apply(additive);
     }

--- a/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
+++ b/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
@@ -72,37 +72,33 @@ public final class VeilRenderType extends RenderType {
                 .createCompositeState(false);
         return create(Veil.MODID + ":quasar_particle", VeilVertexFormat.QUASAR_PARTICLE, VertexFormat.Mode.QUADS, SMALL_BUFFER_SIZE, false, false, state);
     });
-    private static final Function<ResourceLocation, RenderType> QUASAR_TRAIL = Util.memoize((texture) -> {
+    private static final BiFunction<ResourceLocation, Boolean, RenderType> QUASAR_TRAIL = Util.memoize((texture, additive) -> {
         CompositeState state = CompositeState.builder()
                 .setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
                 .setTextureState(new TextureStateShard(texture, false, false))
-                .setTransparencyState(ADDITIVE_TRANSPARENCY)
+                .setTransparencyState(additive ? ADDITIVE_TRANSPARENCY : TRANSLUCENT_TRANSPARENCY)
                 .setWriteMaskState(COLOR_DEPTH_WRITE)
                 .setCullState(NO_CULL)
                 .createCompositeState(false);
         return RenderType.create(Veil.MODID + ":quasar_trail", DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.TRIANGLE_STRIP, TRANSIENT_BUFFER_SIZE, false, false, state);
     });
-    private static final RenderType NO_TEXTURE_QUASAR_TRAIL = RenderType.create(
-            Veil.MODID + ":quasar_trail",
-            DefaultVertexFormat.NEW_ENTITY,
-            VertexFormat.Mode.TRIANGLE_STRIP,
-            TRANSIENT_BUFFER_SIZE,
-            false,
-            false,
-            CompositeState.builder()
-                    .setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
-                    .setTextureState(WHITE_TEXTURE)
-                    .setTransparencyState(ADDITIVE_TRANSPARENCY)
-                    .setWriteMaskState(COLOR_DEPTH_WRITE)
-                    .setCullState(NO_CULL)
-                    .createCompositeState(false));
+    private static final Function<Boolean, RenderType> NO_TEXTURE_QUASAR_TRAIL = Util.memoize((additive) -> {
+        CompositeState state = CompositeState.builder()
+                .setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_EMISSIVE_SHADER)
+                .setTextureState(WHITE_TEXTURE)
+                .setTransparencyState(additive ? ADDITIVE_TRANSPARENCY : TRANSLUCENT_TRANSPARENCY)
+                .setWriteMaskState(COLOR_DEPTH_WRITE)
+                .setCullState(NO_CULL)
+                .createCompositeState(false);
+        return RenderType.create(Veil.MODID + ":quasar_trail", DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.TRIANGLE_STRIP, TRANSIENT_BUFFER_SIZE, false, false, state);
+    }) ;
 
     public static RenderType quasarParticle(ResourceLocation texture, boolean additive) {
         return QUASAR_PARTICLE.apply(texture, additive);
     }
 
-    public static RenderType quasarTrail(@Nullable ResourceLocation texture) {
-        return texture != null ? QUASAR_TRAIL.apply(texture) : NO_TEXTURE_QUASAR_TRAIL;
+    public static RenderType quasarTrail(@Nullable ResourceLocation texture, boolean additive) {
+        return texture != null ? QUASAR_TRAIL.apply(texture, additive) : NO_TEXTURE_QUASAR_TRAIL.apply(additive);
     }
 
     public static TransparencyStateShard noTransparencyShard() {

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/TrailSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/TrailSettings.java
@@ -30,6 +30,7 @@ public class TrailSettings implements EditorAttributeProvider {
             Codec.FLOAT.fieldOf("trailPointModifier").forGetter(settings -> 1.0F),
             Trail.TilingMode.CODEC.optionalFieldOf("tilingMode", Trail.TilingMode.STRETCH).forGetter(settings -> settings.tilingMode),
             Codec.BOOL.optionalFieldOf("billboard", true).forGetter(settings -> settings.billboard),
+            Codec.BOOL.optionalFieldOf("additive", false).forGetter(settings -> settings.additive),
             Codec.BOOL.optionalFieldOf("parentRotation", false).forGetter(settings -> settings.parentRotation)
     ).apply(instance, TrailSettings::new));
 
@@ -41,10 +42,11 @@ public class TrailSettings implements EditorAttributeProvider {
     private ResourceLocation trailTexture;
     private Trail.TilingMode tilingMode;
     private boolean billboard;
+    private boolean additive;
     private boolean parentRotation;
     private float trailWidthModifierFloat = 1f;
 
-    public TrailSettings(int trailFrequency, int trailLength, Vector4fc trailColor, TrailWidthModifier trailWidthModifier, @Nullable ResourceLocation trailTexture, TrailPointModifier trailPointModifier, Trail.TilingMode tilingMode, boolean billboard, boolean parentRotation) {
+    public TrailSettings(int trailFrequency, int trailLength, Vector4fc trailColor, TrailWidthModifier trailWidthModifier, @Nullable ResourceLocation trailTexture, TrailPointModifier trailPointModifier, Trail.TilingMode tilingMode, boolean billboard, boolean additive, boolean parentRotation) {
         this.trailFrequency = trailFrequency;
         this.trailLength = trailLength;
         this.trailColor = new Vector4f(trailColor);
@@ -53,10 +55,11 @@ public class TrailSettings implements EditorAttributeProvider {
         this.trailPointModifier = trailPointModifier;
         this.tilingMode = tilingMode;
         this.billboard = billboard;
+        this.additive = additive;
         this.parentRotation = parentRotation;
     }
 
-    private TrailSettings(int trailFrequency, int trailLength, Vector4fc trailColor, float trailWidthModifier, Optional<ResourceLocation> trailTexture, float trailPointModifier, Trail.TilingMode tilingMode, boolean billboard, boolean parentRotation) {
+    private TrailSettings(int trailFrequency, int trailLength, Vector4fc trailColor, float trailWidthModifier, Optional<ResourceLocation> trailTexture, float trailPointModifier, Trail.TilingMode tilingMode, boolean billboard, boolean additive, boolean parentRotation) {
         this.trailFrequency = trailFrequency;
         this.trailLength = trailLength;
         this.trailColor = new Vector4f(trailColor);
@@ -65,11 +68,12 @@ public class TrailSettings implements EditorAttributeProvider {
         this.trailPointModifier = (point, index, velocity) -> point;
         this.tilingMode = tilingMode;
         this.billboard = billboard;
+        this.additive = additive;
         this.parentRotation = parentRotation;
     }
 
     public TrailSettings() {
-        this(1, 20, new Vector4f(1), 1, Optional.empty(), 1, Trail.TilingMode.STRETCH, true, false);
+        this(1, 20, new Vector4f(1), 1, Optional.empty(), 1, Trail.TilingMode.STRETCH, true, false, false);
     }
 
     public void setParentRotation(boolean parentRotation) {
@@ -78,6 +82,14 @@ public class TrailSettings implements EditorAttributeProvider {
 
     public boolean getParentRotation() {
         return this.parentRotation;
+    }
+
+    public boolean getAdditive() {
+        return additive;
+    }
+
+    public void setAdditive(boolean additive) {
+        this.additive = additive;
     }
 
     public void setBillboard(boolean billboard) {
@@ -145,9 +157,18 @@ public class TrailSettings implements EditorAttributeProvider {
     }
 
     public void renderImGuiAttributes() {
-        ImString trailTextureString = new ImString(this.trailTexture == null ? "" : this.trailTexture.toString());
-        if (ImGui.inputText("Trail Texture", trailTextureString)) {
-            this.trailTexture = trailTextureString.get().isBlank() ? null : ResourceLocation.parse(trailTextureString.get());
+        ImString trailTextureString = new ImString(this.trailTexture == null ? "" : this.trailTexture.toString(), 999);
+
+        if (ImGui.inputTextWithHint("Trail Texture", "namespace:path", trailTextureString)) {
+            if (trailTextureString.isEmpty()) {
+                this.trailTexture = null;
+            }
+
+            try {
+                this.trailTexture = ResourceLocation.parse(trailTextureString.get());
+            } catch (Exception ignored) {
+
+            }
         }
 
         ImInt trailFrequencyInt = new ImInt(this.trailFrequency);
@@ -173,6 +194,9 @@ public class TrailSettings implements EditorAttributeProvider {
         ImBoolean billboardBoolean = new ImBoolean(this.billboard);
         ImGui.checkbox("Billboard", billboardBoolean);
         this.billboard = billboardBoolean.get();
+        ImBoolean additiveBoolean = new ImBoolean(this.additive);
+        ImGui.checkbox("Additive", additiveBoolean);
+        this.additive = additiveBoolean.get();
         ImBoolean parentRotationBoolean = new ImBoolean(this.parentRotation);
         ImGui.checkbox("Parent Rotation", parentRotationBoolean);
         this.parentRotation = parentRotationBoolean.get();

--- a/common/src/main/java/foundry/veil/api/quasar/fx/Trail.java
+++ b/common/src/main/java/foundry/veil/api/quasar/fx/Trail.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
+import java.util.*;
 import java.util.function.Function;
 
 public class Trail {
@@ -28,8 +29,8 @@ public class Trail {
                 .build();
     }
 
-    private Vec3[] points;
-    private Vec3[] rotations;
+    private List<Vec3> points = new ArrayList<>();
+    private final List<Vec3> rotations = new ArrayList<>();
     private int color;
     private Function<Float, Float> widthFunction;
     private int length = 100;
@@ -38,6 +39,7 @@ public class Trail {
     private int frequency = 1;
     private float minDistance = 0f;
     private ResourceLocation texture = null;
+    private boolean additive = false;
     private boolean parentRotation = false;
     private int timeout = 0;
 
@@ -48,17 +50,18 @@ public class Trail {
         this.frequency = settings.getTrailFrequency();
         this.tilingMode = settings.getTilingMode();
         this.texture = settings.getTrailTexture();
+        this.additive = settings.getAdditive();
         this.parentRotation = settings.getParentRotation();
     }
 
-    public Trail(Vec3[] points, int color, Function<Float, Float> widthFunction) {
-        this.points = points;
+    public Trail(Collection<Vec3> points, int color, Function<Float, Float> widthFunction) {
+        this.points.addAll(points);
         this.color = color;
         this.widthFunction = widthFunction;
     }
 
     public Trail(int color, Function<Float, Float> widthFunction) {
-        this(new Vec3[]{Vec3.ZERO}, color, widthFunction);
+        this(List.of(), color, widthFunction);
     }
 
     public void setParentRotation(boolean parentRotation) {
@@ -87,7 +90,7 @@ public class Trail {
             System.arraycopy(points, points.length - this.length, newPoints, 0, this.length);
             points = newPoints;
         }
-        this.points = points;
+        this.points = new ArrayList<>(Arrays.asList(points));
     }
 
     public void setColor(int color) {
@@ -102,6 +105,14 @@ public class Trail {
         this.billboard = billboard;
     }
 
+    public boolean getAdditive() {
+        return additive;
+    }
+
+    public void setAdditive(boolean additive) {
+        this.additive = additive;
+    }
+
     public void setWidthFunction(Function<Float, Float> widthFunction) {
         this.widthFunction = widthFunction;
     }
@@ -114,114 +125,76 @@ public class Trail {
         return this.length;
     }
 
-    public void pushPoint(Vec3 point) {
-        if (this.timeout > Minecraft.getInstance().getWindow().getRefreshRate() * 5 && this.timeout % 3 == 0) {
-            //remove the last point in the array
-            Vec3[] newPoints = new Vec3[this.points.length - 1];
-            System.arraycopy(this.points, 1, newPoints, 0, this.points.length - 1);
-            this.points = newPoints;
+    public void pushRotatedPoint(Vec3 point, Vec3 rotation) {
+        if (this.timeout > 80 && this.timeout % 5 == 0 && !this.points.isEmpty()) {
+            this.points.removeLast();
+            this.rotations.removeLast();
             return;
         }
-        if (this.points.length == 0) {
-            this.points = new Vec3[]{point};
+        if (this.points.isEmpty()) {
+            this.points.addFirst(point);
+            this.rotations.addFirst(rotation);
             return;
         }
-        if (this.points[this.points.length - 1].distanceTo(point) < this.minDistance) {
+        if (this.points.getLast().distanceTo(point) < this.minDistance) {
             this.timeout++;
             return;
         }
         // test if point is same as last point
-        if (this.points[this.points.length - 1].equals(point)) {
+        if (!this.points.isEmpty() && this.points.getLast().equals(point)) {
             this.timeout++;
-            return;
-        }
-        // add point to end of array and remove first point if array is longer than length
-        if (this.points[0] == Vec3.ZERO) {
-            this.points[0] = point;
             return;
         }
         this.timeout = 0;
-        Vec3[] newPoints = new Vec3[this.points.length + 1];
-        System.arraycopy(this.points, 0, newPoints, 0, this.points.length);
-        newPoints[this.points.length] = point;
-        if (newPoints.length > this.length) {
-            Vec3[] newPoints2 = new Vec3[this.length];
-            System.arraycopy(newPoints, 1, newPoints2, 0, this.length);
-            newPoints = newPoints2;
+        this.points.addFirst(point);
+        this.rotations.addFirst(rotation);
+
+        if (this.points.size() > this.length) {
+            this.points.removeLast();
+            this.rotations.removeLast();
         }
-        this.points = newPoints;
     }
 
-    public void pushRotatedPoint(Vec3 point, Vec3 rotation) {
-        if (this.timeout > Minecraft.getInstance().getWindow().getRefreshRate() * 5 && this.timeout % 5 == 0 && this.points.length > 0) {
-            //remove the last point in the array
-            Vec3[] newPoints = new Vec3[this.points.length - 1];
-            System.arraycopy(this.points, 1, newPoints, 0, this.points.length - 1);
-            this.points = newPoints;
-            Vec3[] newRotations = new Vec3[this.rotations.length - 1];
-            System.arraycopy(this.rotations, 1, newRotations, 0, this.rotations.length - 1);
-            this.rotations = newRotations;
-            return;
-        }
-        if (this.points.length == 0) {
-            this.points = new Vec3[]{point};
-            this.rotations = new Vec3[]{rotation};
-            return;
-        }
-        if (this.points[0] == Vec3.ZERO) {
-            this.points[0] = point;
-            this.rotations = new Vec3[]{rotation};
-            return;
-        }
-        if (this.points[this.points.length - 1].distanceTo(point) < this.minDistance) {
-            this.timeout++;
-            return;
-        }
-        // test if point is same as last point
-        if (this.points.length > 0 && this.points[this.points.length - 1].equals(point)) {
-            this.timeout++;
-            return;
-        }
-        if (this.rotations == null) {
-            this.rotations = new Vec3[]{rotation};
-        }
-        // add point to end of array and remove first point if array is longer than length
-        Vec3[] newPoints = new Vec3[this.points.length + 1];
-        Vec3[] newRotations = new Vec3[this.points.length + 1];
-        System.arraycopy(this.points, 0, newPoints, 0, this.points.length);
-        System.arraycopy(this.rotations, 0, newRotations, 0, this.rotations.length);
-        newPoints[this.points.length] = point;
-        newRotations[this.rotations.length] = rotation;
-        if (newPoints.length > this.length) {
-            Vec3[] newPoints2 = new Vec3[this.length];
-            Vec3[] newRotations2 = new Vec3[this.length];
-            System.arraycopy(newPoints, 1, newPoints2, 0, this.length);
-            System.arraycopy(newRotations, 1, newRotations2, 0, this.length);
-            newPoints = newPoints2;
-            newRotations = newRotations2;
-        }
-        this.points = newPoints;
-        this.rotations = newRotations;
-    }
-
-    public void render(MatrixStack stack, VertexConsumer consumer, int light) {
+    public void render(MatrixStack stack, VertexConsumer consumer, int light, float partialTicks, Vec3 target, Vec3 targetRotation) {
         // Not enough geometry to render anything
-        if (this.points.length < 1) {
+        if (this.points.isEmpty()) {
             return;
         }
 
-        Vector3f[][] corners = new Vector3f[this.points.length][2];
-        for (int i = 0; i < this.points.length; i++) {
+        List<Vec3> lerpedPoints = new ArrayList<>();
+        for (int i = 0; i < this.points.size(); i++) {
+            Vec3 lerpedPoint = this.points.get(i);
+            if (i == 0) {
+                lerpedPoint = lerpedPoint.lerp(target, partialTicks);
+            } else {
+                lerpedPoint = lerpedPoint.lerp(this.points.get(i - 1), partialTicks);
+            }
+            lerpedPoints.add(lerpedPoint);
+        }
+
+        List<Vec3> lerpedRotations = new ArrayList<>();
+        for (int i = 0; i < this.rotations.size(); i++) {
+            Vec3 lerpedRotation = this.rotations.get(i);
+            if (i == 0) {
+                lerpedRotation = lerpedRotation.lerp(targetRotation, partialTicks);
+            } else {
+                lerpedRotation = lerpedRotation.lerp(this.rotations.get(i - 1), partialTicks);
+            }
+            lerpedRotations.add(lerpedRotation);
+        }
+
+        Vector3f[][] corners = new Vector3f[lerpedPoints.size()][2];
+        for (int i = 0; i < lerpedPoints.size(); i++) {
             if (i % this.frequency != 0) {
                 continue;
             }
-            float width = this.widthFunction.apply((float) i / (this.points.length - 1));
+            float width = this.widthFunction.apply((float) i / (lerpedPoints.size() - 1));
             Vector3f topOffset = new Vector3f(0, (width / 2f), 0);
             Vector3f bottomOffset = new Vector3f(0, -(width / 2f), 0);
             if (this.billboard) {
-                Vec3 a = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition().subtract(this.points[i]).normalize();
+                Vec3 a = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition().subtract(lerpedPoints.get(i)).normalize();
                 Vector3f cameraDirection = new Vector3f((float) a.x, (float) a.y, (float) a.z);
-                Vec3 b = this.points[Math.min(i + this.frequency, this.points.length - 1)].subtract(this.points[i]).normalize();
+                Vec3 b = lerpedPoints.get(Math.min(i + this.frequency, lerpedPoints.size() - 1)).subtract(lerpedPoints.get(i)).normalize();
                 Vector3f dirToNextPoint = new Vector3f((float) b.x(), (float) b.y(), (float) b.z());
                 Vector3f axis = new Vector3f(cameraDirection);
                 // invert the axis
@@ -231,10 +204,10 @@ public class Trail {
                 topOffset.mul(width / 2f);
                 bottomOffset = new Vector3f(axis);
                 bottomOffset.mul(-width / 2f);
-            } else if (this.rotations[i] != null && this.parentRotation) {
-                Vec3 a = this.rotations[Math.min(i + this.frequency, this.rotations.length - 1)];
+            } else if (lerpedRotations.get(i) != null && this.parentRotation) {
+                Vec3 a = lerpedRotations.get(Math.min(i + this.frequency, lerpedRotations.size() - 1));
                 Vector3f cameraDirection = new Vector3f((float) a.x, (float) a.y, (float) a.z);
-                Vec3 b = this.points[Math.min(i + this.frequency, this.points.length - 1)].subtract(this.points[i]).normalize();
+                Vec3 b = lerpedPoints.get(Math.min(i + this.frequency, lerpedPoints.size() - 1)).subtract(lerpedPoints.get(i)).normalize();
                 Vector3f dirToNextPoint = new Vector3f((float) b.x(), (float) b.y(), (float) b.z());
                 Vector3f axis = new Vector3f(cameraDirection);
                 // invert the axis
@@ -245,8 +218,8 @@ public class Trail {
                 bottomOffset = new Vector3f(axis);
                 bottomOffset.mul(-width / 2f);
             }
-            topOffset.add((float) this.points[i].x, (float) this.points[i].y, (float) this.points[i].z);
-            bottomOffset.add((float) this.points[i].x, (float) this.points[i].y, (float) this.points[i].z);
+            topOffset.add((float) lerpedPoints.get(i).x, (float) lerpedPoints.get(i).y, (float) lerpedPoints.get(i).z);
+            bottomOffset.add((float) lerpedPoints.get(i).x, (float) lerpedPoints.get(i).y, (float) lerpedPoints.get(i).z);
             corners[i / this.frequency][0] = topOffset;
             corners[i / this.frequency][1] = bottomOffset;
         }
@@ -261,8 +234,6 @@ public class Trail {
         for (int i = 0; i < corners.length; i++) {
             Vector3f top = corners[i][0];
             Vector3f bottom = corners[i][1];
-//            Vector3f nextTop = corners[i + 1][0];
-//            Vector3f nextBottom = corners[i + 1][1];
             if (top == null || bottom == null) {
                 continue;
             }
@@ -273,8 +244,6 @@ public class Trail {
             Matrix4f matrix4f = stack.position();
             consumer.addVertex(matrix4f, bottom.x(), bottom.y(), bottom.z()).setColor(r, g, b, a).setUv(u, 0).setOverlay(OverlayTexture.NO_OVERLAY).setLight(light).setNormal(0, 1, 0);
             consumer.addVertex(matrix4f, top.x(), top.y(), top.z()).setColor(r, g, b, a).setUv(u, 1).setOverlay(OverlayTexture.NO_OVERLAY).setLight(light).setNormal(0, 1, 0);
-//            consumer.vertex(matrix4f, nextTop.x(), nextTop.y(), nextTop.z()).color(r, g, b, a).uv(u1, 1).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
-//            consumer.vertex(matrix4f, nextBottom.x(), nextBottom.y(), nextBottom.z()).color(r, g, b, a).uv(u1, 0).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
         }
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -203,6 +203,7 @@ public class ParticleEmitter {
         Iterator<QuasarParticle> iterator = this.particles.iterator();
         while (iterator.hasNext()) {
             QuasarParticle particle = iterator.next();
+            particle.getRenderData().tickTrails();
             particle.tick();
 
             if (particle.isRemoved()) {
@@ -247,7 +248,7 @@ public class ParticleEmitter {
 
             particle.render(partialTicks);
 
-            renderData.renderTrails(matrixStack, bufferSource, projectedView, LightTexture.FULL_BRIGHT);
+            renderData.renderTrails(matrixStack, bufferSource, projectedView, LightTexture.FULL_BRIGHT, partialTicks);
 
             Vector3dc renderPosition = renderData.getRenderPosition();
             renderOffset.set(

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderData.java
@@ -174,8 +174,18 @@ public final class RenderData {
         return this.trails;
     }
 
+    public void tickTrails() {
+        if (this.trails.isEmpty()) {
+            return;
+        }
+
+        for (Trail trail : this.trails) {
+            trail.pushRotatedPoint(new Vec3(this.particle.getPosition().x, this.particle.getPosition().y, this.particle.getPosition().z), new Vec3(this.particle.getRotation()));
+        }
+    }
+
     // TODO move to renderer
-    public void renderTrails(MatrixStack matrixStack, MultiBufferSource bufferSource, Vec3 cameraPos, int packedLight) {
+    public void renderTrails(MatrixStack matrixStack, MultiBufferSource bufferSource, Vec3 cameraPos, int packedLight, float partialTicks) {
         if (this.trails.isEmpty()) {
             return;
         }
@@ -183,8 +193,7 @@ public final class RenderData {
         matrixStack.matrixPush();
         matrixStack.translate(-cameraPos.x(), -cameraPos.y(), -cameraPos.z());
         for (Trail trail : this.trails) {
-            trail.pushRotatedPoint(new Vec3(this.prevPosition.x, this.prevPosition.y, this.prevPosition.z), new Vec3(this.prevRotation.x, this.prevRotation.y, this.prevRotation.z));
-            trail.render(matrixStack, bufferSource.getBuffer(VeilRenderType.quasarTrail(trail.getTexture())), packedLight);
+            trail.render(matrixStack, bufferSource.getBuffer(VeilRenderType.quasarTrail(trail.getTexture(), trail.getAdditive())), packedLight, partialTicks, new Vec3(this.particle.getPosition().x, this.particle.getPosition().y, this.particle.getPosition().z), new Vec3(this.particle.getRotation()));
         }
         matrixStack.matrixPop();
     }


### PR DESCRIPTION
Quasar's trail module is cool, but it has some flaws. Despite running every frame, it is not smooth, instead adhering to the 20 TPS tick loop. This PR improves it to only add trail points on the tick loop and interpolate them with `partialTicks` during rendering. Additionally, this PR gives the trails the option to not use additive transparency, with the alternative being translucent for parity with Quasar particles.