### PR TITLE
Add raymarched in-scattering as an option for deferred lights

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/render/VeilLevelPerspectiveRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/VeilLevelPerspectiveRenderer.java
@@ -170,7 +170,7 @@ public final class VeilLevelPerspectiveRenderer {
             // Draw lights
             if (drawLights) {
                 ProfilerFiller profiler = Minecraft.getInstance().getProfiler();
-                if (VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum())) {
+                if (VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum(), true)) {
                     VeilRenderSystem.compositeLights(profiler);
                 } else {
                     AdvancedFbo.unbind();

--- a/common/src/main/java/foundry/veil/api/client/render/VeilRenderSystem.java
+++ b/common/src/main/java/foundry/veil/api/client/render/VeilRenderSystem.java
@@ -1276,10 +1276,11 @@ public final class VeilRenderSystem {
     }
 
     @ApiStatus.Internal
-    public static boolean drawLights(ProfilerFiller profiler, CullFrustum cullFrustum) {
+    public static boolean drawLights(ProfilerFiller profiler, CullFrustum cullFrustum, boolean renderInscattering) {
         FramebufferManager framebufferManager = renderer.getFramebufferManager();
         AdvancedFbo lightFbo = framebufferManager.getFramebuffer(VeilFramebuffers.LIGHT);
-        if (lightFbo == null) {
+        AdvancedFbo lightInscatteringFbo = framebufferManager.getFramebuffer(VeilFramebuffers.LIGHT_INSCATTERING);
+        if (lightFbo == null || lightInscatteringFbo == null) {
             AdvancedFbo.unbind();
             return false;
         }
@@ -1300,7 +1301,7 @@ public final class VeilRenderSystem {
 
         LightRenderer lightRenderer = renderer.getLightRenderer();
         profiler.push("draw_lights");
-        boolean rendered = lightRenderer.render(cullFrustum, lightFbo);
+        boolean rendered = lightRenderer.render(cullFrustum, lightFbo, lightInscatteringFbo, renderInscattering);
         profiler.pop();
 
         renderProfiler.pop();

--- a/common/src/main/java/foundry/veil/api/client/render/framebuffer/VeilFramebuffers.java
+++ b/common/src/main/java/foundry/veil/api/client/render/framebuffer/VeilFramebuffers.java
@@ -17,6 +17,7 @@ public final class VeilFramebuffers {
     public static final ResourceLocation FIRST_PERSON = buffer("first_person");
     public static final ResourceLocation BLOOM = buffer("bloom");
     public static final ResourceLocation LIGHT = buffer("light");
+    public static final ResourceLocation LIGHT_INSCATTERING = buffer("light_inscattering");
     public static final ResourceLocation POST = buffer("post");
 
     public static final ResourceLocation TRANSLUCENT_TARGET = transparency("translucent");

--- a/common/src/main/java/foundry/veil/api/client/render/light/LightGuideProvider.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/LightGuideProvider.java
@@ -1,0 +1,18 @@
+package foundry.veil.api.client.render.light;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import foundry.veil.api.client.render.MatrixStack;
+
+/**
+ * Provides extra information for given light data by rendering guides into the world.
+ *
+ * @author Neddslayer
+ */
+public interface LightGuideProvider {
+
+    /**
+     * Render the light guides using the VertexConsumer.
+     */
+    void renderLightGuide(MatrixStack stack, VertexConsumer consumer);
+
+}

--- a/common/src/main/java/foundry/veil/api/client/render/light/data/AreaLightData.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/data/AreaLightData.java
@@ -34,6 +34,7 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
     protected float angle;
     protected float distance;
     protected boolean occlusionEnabled;
+    protected float inscattering;
 
     public AreaLightData() {
         this.matrix = new Matrix4d();
@@ -45,6 +46,7 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
         this.angle = (float) Math.toRadians(45);
         this.distance = 1.0F;
         this.occlusionEnabled = false;
+        this.inscattering = 0.0F;
     }
 
     /**
@@ -137,6 +139,13 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
     }
 
     /**
+     * @return The strength of the light's in-scattering effect.
+     */
+    public float getInscatteringStrength() {
+        return this.inscattering;
+    }
+
+    /**
      * Sets the size of the light's surface
      *
      * @param x The length, in blocks, of the light's surface.
@@ -172,6 +181,12 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
 
     public AreaLightData setOcclusionEnabled(boolean occlusionEnabled) {
         this.occlusionEnabled = occlusionEnabled;
+        this.markDirty();
+        return this;
+    }
+
+    public AreaLightData setInscatteringStrength(float inscattering) {
+        this.inscattering = inscattering;
         this.markDirty();
         return this;
     }
@@ -221,6 +236,7 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
         buffer.putShort((short) Mth.clamp((int) (this.angle * MAX_ANGLE_SIZE), 0, 65535));
         buffer.putFloat(this.distance);
         buffer.putFloat(this.occlusionEnabled ? 1.0F : 0.0F);
+        buffer.putFloat(this.inscattering);
     }
 
     @Override
@@ -260,6 +276,8 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
 
         float[] editAngle = new float[]{this.angle};
         float[] editDistance = new float[]{this.distance};
+
+        float[] editInscattering = new float[]{this.inscattering};
 
         if (ImGui.dragFloat2("size", editSize, 0.02F, 0.0001F)) {
             this.setSize(editSize[0], editSize[1]);
@@ -317,8 +335,11 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
         }
 
         if (ImGui.checkbox("Occluded", this.occlusionEnabled)) {
-            this.occlusionEnabled = !this.occlusionEnabled;
-            this.markDirty();
+            this.setOcclusionEnabled(!this.occlusionEnabled);
+        }
+
+        if (ImGui.dragScalar("In-scattering", editInscattering, 0.01F, 0.0F)) {
+            this.setInscatteringStrength(editInscattering[0]);
         }
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/render/light/data/AreaLightData.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/data/AreaLightData.java
@@ -1,11 +1,14 @@
 package foundry.veil.api.client.render.light.data;
 
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import foundry.veil.api.client.color.Colorc;
 import foundry.veil.api.client.editor.EditorAttributeProvider;
 import foundry.veil.api.client.registry.LightTypeRegistry;
 import foundry.veil.api.client.render.CullFrustum;
+import foundry.veil.api.client.render.MatrixStack;
 import foundry.veil.api.client.render.light.DDALightData;
 import foundry.veil.api.client.render.light.InstancedLightData;
+import foundry.veil.api.client.render.light.LightGuideProvider;
 import imgui.ImGui;
 import net.minecraft.client.Camera;
 import net.minecraft.util.Mth;
@@ -21,7 +24,7 @@ import java.nio.ByteBuffer;
  *
  * @since 2.0.0
  */
-public class AreaLightData extends LightData implements InstancedLightData, DDALightData, EditorAttributeProvider {
+public class AreaLightData extends LightData implements InstancedLightData, DDALightData, EditorAttributeProvider, LightGuideProvider {
 
     private static final float MAX_ANGLE_SIZE = (float) (65535.0 / 2.0 / Math.PI);
 
@@ -341,5 +344,38 @@ public class AreaLightData extends LightData implements InstancedLightData, DDAL
         if (ImGui.dragScalar("In-scattering", editInscattering, 0.01F, 0.0F)) {
             this.setInscatteringStrength(editInscattering[0]);
         }
+    }
+
+    @Override
+    public void renderLightGuide(MatrixStack stack, VertexConsumer consumer) {
+        stack.matrixPush();
+
+        stack.translate(this.position.x, this.position.y, this.position.z);
+        Vector3f rot = this.orientation.getEulerAnglesXYZ(new Vector3f()).mul(-1);
+        stack.rotate(new Quaternionf().rotateX(rot.x).rotateLocalY(rot.y).rotateLocalZ(rot.z));
+
+        Matrix4f pose = stack.position();
+
+        consumer.addVertex(pose, -this.size.x, -this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -this.size.x,  this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose,  this.size.x,  this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose,  this.size.x, -this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -this.size.x, -this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+
+        Vector3f endSize = new Vector3f(this.size.x + (this.distance * (float)Math.tan(this.angle * 0.5)), this.size.y + (this.distance * (float)Math.tan(this.angle * 0.5)), this.distance);
+
+        consumer.addVertex(pose, -endSize.x, -endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -endSize.x, endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -this.size.x,  this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -endSize.x, endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, endSize.x, endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose,  this.size.x,  this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, endSize.x, endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, endSize.x, -endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose,  this.size.x, -this.size.y, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, endSize.x, -endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        consumer.addVertex(pose, -endSize.x, -endSize.y, this.distance).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+
+        stack.matrixPop();
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/render/light/data/PointLightData.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/data/PointLightData.java
@@ -1,14 +1,19 @@
 package foundry.veil.api.client.render.light.data;
 
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import foundry.veil.api.client.color.Colorc;
 import foundry.veil.api.client.editor.EditorAttributeProvider;
 import foundry.veil.api.client.registry.LightTypeRegistry;
 import foundry.veil.api.client.render.CullFrustum;
+import foundry.veil.api.client.render.MatrixStack;
 import foundry.veil.api.client.render.light.DDALightData;
 import foundry.veil.api.client.render.light.IndirectLightData;
+import foundry.veil.api.client.render.light.LightGuideProvider;
 import imgui.ImGui;
 import net.minecraft.client.Camera;
+import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.joml.Vector3fc;
@@ -20,7 +25,7 @@ import java.nio.ByteBuffer;
  *
  * @since 2.0.0
  */
-public class PointLightData extends LightData implements IndirectLightData, DDALightData, EditorAttributeProvider {
+public class PointLightData extends LightData implements IndirectLightData, DDALightData, EditorAttributeProvider, LightGuideProvider {
 
     protected final Vector3d position;
     protected float radius;
@@ -199,5 +204,32 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
         if (ImGui.dragScalar("In-scattering", editInscattering, 0.01F, 0.0F)) {
             this.setInscatteringStrength(editInscattering[0]);
         }
+    }
+
+    @Override
+    public void renderLightGuide(MatrixStack stack, VertexConsumer consumer) {
+        stack.matrixPush();
+
+        stack.translate(this.position.x, this.position.y, this.position.z);
+
+        Matrix4f pose = stack.position();
+
+        for (int i = -8; i < 25; i++) {
+            consumer.addVertex(pose, (float)Math.sin(i / 32.0f * Mth.TWO_PI) * this.radius, 0, (float)Math.cos(i / 32.0f * Mth.TWO_PI) * this.radius).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        }
+
+        for (int i = -8; i < 25; i++) {
+            consumer.addVertex(pose, (float)Math.sin(i / 32.0f * Mth.TWO_PI) * this.radius, (float)Math.cos(i / 32.0f * Mth.TWO_PI) * this.radius, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        }
+
+        for (int i = 25; i >= 16; i--) {
+            consumer.addVertex(pose, (float)Math.sin(i / 32.0f * Mth.TWO_PI) * this.radius, (float)Math.cos(i / 32.0f * Mth.TWO_PI) * this.radius, 0).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        }
+
+        for (int i = -8; i < 25; i++) {
+            consumer.addVertex(pose, 0, (float)Math.sin(i / 32.0f * Mth.TWO_PI) * this.radius, (float)Math.cos(i / 32.0f * Mth.TWO_PI) * this.radius).setColor(this.color.red(), this.color.green(), this.color.blue(), this.color.alpha());
+        }
+
+        stack.matrixPop();
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/render/light/data/PointLightData.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/data/PointLightData.java
@@ -25,11 +25,13 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
     protected final Vector3d position;
     protected float radius;
     protected boolean occlusionEnabled;
+    protected float inscattering;
 
     public PointLightData() {
         this.position = new Vector3d();
         this.radius = 1.0F;
         this.occlusionEnabled = false;
+        this.inscattering = 0.0F;
     }
 
     @Override
@@ -58,6 +60,13 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
         return this.occlusionEnabled;
     }
 
+    /**
+     * @return The strength of the light's in-scattering effect.
+     */
+    public float getInscatteringStrength() {
+        return this.inscattering;
+    }
+
     public PointLightData setPosition(Vector3dc pos) {
         this.position.set(pos);
         this.markDirty();
@@ -78,6 +87,12 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
 
     public PointLightData setOcclusionEnabled(boolean occlusionEnabled) {
         this.occlusionEnabled = occlusionEnabled;
+        this.markDirty();
+        return this;
+    }
+
+    public PointLightData setInscatteringStrength(float inscattering) {
+        this.inscattering = inscattering;
         this.markDirty();
         return this;
     }
@@ -126,6 +141,7 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
         buffer.putFloat(this.color.blue() * this.brightness);
         buffer.putFloat(this.radius);
         buffer.putFloat(this.occlusionEnabled ? 1.0F : 0.0F);
+        buffer.putFloat(this.inscattering);
     }
 
     @Override
@@ -148,6 +164,8 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
         double[] editZ = new double[]{this.position.z()};
 
         float[] editRadius = new float[]{this.radius};
+
+        float[] editInscattering = new float[]{this.inscattering};
 
         float totalWidth = ImGui.calcItemWidth();
         ImGui.pushItemWidth(totalWidth / 3.0F - (ImGui.getStyle().getItemInnerSpacingX() * 0.58F));
@@ -175,8 +193,11 @@ public class PointLightData extends LightData implements IndirectLightData, DDAL
         }
 
         if (ImGui.checkbox("Occluded", this.occlusionEnabled)) {
-            this.occlusionEnabled = !this.occlusionEnabled;
-            this.markDirty();
+            this.setOcclusionEnabled(!this.occlusionEnabled);
+        }
+
+        if (ImGui.dragScalar("In-scattering", editInscattering, 0.01F, 0.0F)) {
+            this.setInscatteringStrength(editInscattering[0]);
         }
     }
 }

--- a/common/src/main/java/foundry/veil/api/client/render/light/renderer/InscatteringLightRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/renderer/InscatteringLightRenderer.java
@@ -1,0 +1,17 @@
+package foundry.veil.api.client.render.light.renderer;
+
+import foundry.veil.api.client.render.light.data.LightData;
+
+public interface InscatteringLightRenderer<T extends LightData> extends LightTypeRenderer<T> {
+
+    /**
+     * Renders inscattering of all prepared lights with this renderer.
+     * <br>
+     * Shaders, custom uniforms, and the way lights are rendered is up to the individual renderer.
+     * This function is not called for the first-person perspective.
+     *
+     * @param lightRenderer The light renderer instance
+     */
+    void renderLightInscattering(LightRenderer lightRenderer);
+
+}

--- a/common/src/main/java/foundry/veil/api/client/render/light/renderer/InscatteringLightRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/renderer/InscatteringLightRenderer.java
@@ -2,6 +2,11 @@ package foundry.veil.api.client.render.light.renderer;
 
 import foundry.veil.api.client.render.light.data.LightData;
 
+/**
+ * Renders in-scattering for deferred lights.
+ *
+ * @author Neddslayer
+ */
 public interface InscatteringLightRenderer<T extends LightData> extends LightTypeRenderer<T> {
 
     /**

--- a/common/src/main/java/foundry/veil/api/client/render/light/renderer/InstancedLightRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/renderer/InstancedLightRenderer.java
@@ -1,14 +1,23 @@
 package foundry.veil.api.client.render.light.renderer;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.MeshData;
+import com.mojang.blaze3d.vertex.*;
+import foundry.veil.Veil;
 import foundry.veil.api.client.render.CullFrustum;
+import foundry.veil.api.client.render.MatrixStack;
+import foundry.veil.api.client.render.VeilRenderBridge;
+import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.light.InstancedLightData;
+import foundry.veil.api.client.render.light.LightGuideProvider;
 import foundry.veil.api.client.render.light.data.LightData;
 import foundry.veil.api.client.render.vertex.VertexArray;
 import foundry.veil.api.client.render.vertex.VertexArrayBuilder;
+import foundry.veil.impl.client.editor.LightInspector;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix4fStack;
 import org.lwjgl.system.MemoryStack;
 
 import java.nio.ByteBuffer;
@@ -210,6 +219,40 @@ public abstract class InstancedLightRenderer<T extends LightData & InstancedLigh
 
         this.bindRenderQuad();
         this.vertexArray.drawInstancedWithRenderType(renderType, this.visibleLights.size());
+
+        // Render light guides
+        if (Veil.IMGUIMC) {
+            RenderSystem.setProjectionMatrix(VeilRenderSystem.renderer().getCameraMatrices().getProjectionMatrix(), VertexSorting.DISTANCE_TO_ORIGIN);
+            Matrix4fStack stack = RenderSystem.getModelViewStack();
+            stack.pushMatrix();
+            stack.set(VeilRenderSystem.renderer().getCameraMatrices().getViewMatrix());
+            RenderSystem.applyModelViewMatrix();
+            Camera camera = Minecraft.getInstance().gameRenderer.getMainCamera();
+            MatrixStack matrixStack = VeilRenderBridge.create(new PoseStack());
+            matrixStack.matrixPush();
+            matrixStack.translate(-camera.getPosition().x, -camera.getPosition().y, -camera.getPosition().z);
+
+            for (LightHandle handle : this.lights) {
+                if (VeilRenderSystem.renderer().getEditorManager().isVisible(i -> i instanceof LightInspector) && handle.getLightData() instanceof LightGuideProvider) {
+                    RenderType debugRenderType = RenderType.debugLineStrip(1);
+                    ByteBufferBuilder bytebufferbuilder = new ByteBufferBuilder(debugRenderType.bufferSize());
+                    BufferBuilder builder = new BufferBuilder(bytebufferbuilder, debugRenderType.mode(), debugRenderType.format());
+                    ((LightGuideProvider) handle.getLightData()).renderLightGuide(matrixStack, builder);
+                    MeshData meshData = builder.build();
+                    if (meshData != null) {
+                        if (renderType.sortOnUpload()) {
+                            ByteBufferBuilder sortBufferBuilder = new ByteBufferBuilder(renderType.bufferSize());
+                            meshData.sortQuads(sortBufferBuilder, RenderSystem.getVertexSorting());
+                        }
+
+                        debugRenderType.draw(meshData);
+                    }
+                }
+            }
+            matrixStack.matrixPop();
+            stack.popMatrix();
+            RenderSystem.applyModelViewMatrix();
+        }
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/api/client/render/light/renderer/InstancedLightRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/renderer/InstancedLightRenderer.java
@@ -24,7 +24,7 @@ import static org.lwjgl.system.MemoryUtil.memAddress;
  * @param <T> The type of lights to render
  * @author Ocelot
  */
-public abstract class InstancedLightRenderer<T extends LightData & InstancedLightData> implements LightTypeRenderer<T> {
+public abstract class InstancedLightRenderer<T extends LightData & InstancedLightData> implements InscatteringLightRenderer<T> {
 
     private static final int MAX_UPLOADS = 400;
 
@@ -78,6 +78,14 @@ public abstract class InstancedLightRenderer<T extends LightData & InstancedLigh
      * @return The render type to use
      */
     protected abstract @Nullable RenderType getRenderType(List<? extends LightRenderHandle<T>> lights);
+
+    /**
+     * Calculates the render type to use for the specified lights' in-scattering.
+     *
+     * @param lights All lights in the order they are in the instanced buffer
+     * @return The render type to use for in-scattering
+     */
+    protected abstract @Nullable RenderType getInscatteringRenderType(List<? extends LightRenderHandle<T>> lights);
 
     private void updateAllLights() {
         try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -162,17 +170,7 @@ public abstract class InstancedLightRenderer<T extends LightData & InstancedLigh
         }
     }
 
-    @Override
-    public void renderLights(LightRenderer lightRenderer) {
-        if (this.visibleLights.isEmpty()) {
-            return;
-        }
-
-        RenderType renderType = this.getRenderType(this.visibleLights);
-        if (renderType == null) {
-            return;
-        }
-
+    private void bindRenderQuad() {
         RenderSystem.glBindBuffer(GL_ARRAY_BUFFER, this.instancedVbo);
 
         boolean resized = false;
@@ -197,6 +195,35 @@ public abstract class InstancedLightRenderer<T extends LightData & InstancedLigh
         }
 
         this.vertexArray.bind();
+    }
+
+    @Override
+    public void renderLights(LightRenderer lightRenderer) {
+        if (this.visibleLights.isEmpty()) {
+            return;
+        }
+
+        RenderType renderType = this.getRenderType(this.visibleLights);
+        if (renderType == null) {
+            return;
+        }
+
+        this.bindRenderQuad();
+        this.vertexArray.drawInstancedWithRenderType(renderType, this.visibleLights.size());
+    }
+
+    @Override
+    public void renderLightInscattering(LightRenderer lightRenderer) {
+        if (this.visibleLights.isEmpty()) {
+            return;
+        }
+
+        RenderType renderType = this.getInscatteringRenderType(this.visibleLights);
+        if (renderType == null) {
+            return;
+        }
+
+        this.bindRenderQuad();
         this.vertexArray.drawInstancedWithRenderType(renderType, this.visibleLights.size());
     }
 

--- a/common/src/main/java/foundry/veil/api/client/render/light/renderer/LightRenderer.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/renderer/LightRenderer.java
@@ -54,7 +54,7 @@ public final class LightRenderer implements NativeResource {
      * @return If any lights were actually rendered
      */
     @ApiStatus.Internal
-    public boolean render(CullFrustum frustum, AdvancedFbo lightFbo) {
+    public boolean render(CullFrustum frustum, AdvancedFbo lightFbo, AdvancedFbo lightInscatteringFbo, boolean renderInscattering) {
         boolean hasRendered = false;
         boolean setupDDA = false;
         VeilRenderer renderer = VeilRenderSystem.renderer();
@@ -88,6 +88,17 @@ public final class LightRenderer implements NativeResource {
                 ddalightRenderer.uploadVoxelGridUniforms(VoxelShadowGrid.getTextureId(), VoxelShadowGrid.getUniformGridPos());
             }
             lightRenderer.renderLights(this);
+
+            if (lightRenderer instanceof InscatteringLightRenderer<?> inscatteringLightRenderer && renderInscattering) {
+                lightInscatteringFbo.bind(true);
+                AdvancedFbo.getMainFramebuffer().resolveToAdvancedFbo(lightInscatteringFbo, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+                inscatteringLightRenderer.renderLightInscattering(this);
+                AdvancedFbo.unbind();
+            }
+        }
+
+        if (hasRendered && !renderInscattering) {
+            lightInscatteringFbo.clear(GL_COLOR_BUFFER_BIT);
         }
 
         if (!hasRendered) {

--- a/common/src/main/java/foundry/veil/impl/client/render/light/AreaLightRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/light/AreaLightRenderer.java
@@ -25,6 +25,7 @@ import java.util.List;
 public class AreaLightRenderer extends InstancedLightRenderer<AreaLightData> implements DDALightRenderer<AreaLightData> {
 
     private static final ResourceLocation RENDER_TYPE = Veil.veilPath("light/area");
+    private static final ResourceLocation INSCATTERING_RENDER_TYPE = Veil.veilPath("light/inscattering/area");
 
     public AreaLightRenderer() {
         super(Float.BYTES * 24 + 2);
@@ -54,6 +55,11 @@ public class AreaLightRenderer extends InstancedLightRenderer<AreaLightData> imp
     @Override
     protected @Nullable RenderType getRenderType(List<? extends LightRenderHandle<AreaLightData>> lights) {
         return VeilRenderType.get(RENDER_TYPE);
+    }
+
+    @Override
+    protected @Nullable RenderType getInscatteringRenderType(List<? extends LightRenderHandle<AreaLightData>> lights) {
+        return VeilRenderType.get(INSCATTERING_RENDER_TYPE);
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/impl/client/render/light/AreaLightRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/light/AreaLightRenderer.java
@@ -27,7 +27,7 @@ public class AreaLightRenderer extends InstancedLightRenderer<AreaLightData> imp
     private static final ResourceLocation RENDER_TYPE = Veil.veilPath("light/area");
 
     public AreaLightRenderer() {
-        super(Float.BYTES * 23 + 2);
+        super(Float.BYTES * 24 + 2);
     }
 
     @Override
@@ -47,7 +47,8 @@ public class AreaLightRenderer extends InstancedLightRenderer<AreaLightData> imp
         builder.setVertexAttribute(6, 2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // size
         builder.setVertexAttribute(7, 2, 1, VertexArrayBuilder.DataType.UNSIGNED_SHORT, true, Float.BYTES * 21); // angle
         builder.setVertexAttribute(8, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21 + 2); // distance
-        builder.setVertexAttribute(9, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21 + 2 + Float.BYTES);
+        builder.setVertexAttribute(9, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21 + 2 + Float.BYTES); // Occlusion
+        builder.setVertexAttribute(10, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21 + 2 + Float.BYTES * 2); // In-scattering
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/impl/client/render/light/InstancedPointLightRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/light/InstancedPointLightRenderer.java
@@ -27,7 +27,7 @@ public class InstancedPointLightRenderer extends InstancedLightRenderer<PointLig
     private static final ResourceLocation RENDER_TYPE = Veil.veilPath("light/point");
 
     public InstancedPointLightRenderer() {
-        super(Float.BYTES * 8);
+        super(Float.BYTES * 9);
     }
 
     @Override
@@ -39,10 +39,11 @@ public class InstancedPointLightRenderer extends InstancedLightRenderer<PointLig
 
     @Override
     protected void setupBufferState(VertexArrayBuilder builder) {
-        builder.setVertexAttribute(1, 2, 3, VertexArrayBuilder.DataType.FLOAT, false, 0);
-        builder.setVertexAttribute(2, 2, 3, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 3);
-        builder.setVertexAttribute(3, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 6);
-        builder.setVertexAttribute(4, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 7);
+        builder.setVertexAttribute(1, 2, 3, VertexArrayBuilder.DataType.FLOAT, false, 0); // LightPosition
+        builder.setVertexAttribute(2, 2, 3, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 3); // Color
+        builder.setVertexAttribute(3, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 6); // Distance
+        builder.setVertexAttribute(4, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 7); // Occluded
+        builder.setVertexAttribute(5, 2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8); // In-scattering
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/impl/client/render/light/InstancedPointLightRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/light/InstancedPointLightRenderer.java
@@ -7,10 +7,7 @@ import com.mojang.blaze3d.vertex.MeshData;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import foundry.veil.Veil;
 import foundry.veil.api.client.render.light.data.PointLightData;
-import foundry.veil.api.client.render.light.renderer.DDALightRenderer;
-import foundry.veil.api.client.render.light.renderer.InstancedLightRenderer;
-import foundry.veil.api.client.render.light.renderer.LightRenderHandle;
-import foundry.veil.api.client.render.light.renderer.LightTypeRenderer;
+import foundry.veil.api.client.render.light.renderer.*;
 import foundry.veil.api.client.render.rendertype.VeilRenderType;
 import foundry.veil.api.client.render.vertex.VertexArrayBuilder;
 import net.minecraft.client.renderer.RenderType;
@@ -25,6 +22,7 @@ import java.util.List;
 public class InstancedPointLightRenderer extends InstancedLightRenderer<PointLightData> implements DDALightRenderer<PointLightData> {
 
     private static final ResourceLocation RENDER_TYPE = Veil.veilPath("light/point");
+    private static final ResourceLocation INSCATTERING_RENDER_TYPE = Veil.veilPath("light/inscattering/point");
 
     public InstancedPointLightRenderer() {
         super(Float.BYTES * 9);
@@ -49,6 +47,11 @@ public class InstancedPointLightRenderer extends InstancedLightRenderer<PointLig
     @Override
     protected @Nullable RenderType getRenderType(List<? extends LightRenderHandle<PointLightData>> lights) {
         return VeilRenderType.get(RENDER_TYPE);
+    }
+
+    @Override
+    protected @Nullable RenderType getInscatteringRenderType(List<? extends LightRenderHandle<PointLightData>> lights) {
+        return VeilRenderType.get(INSCATTERING_RENDER_TYPE);
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/impl/client/render/pipeline/VeilFirstPersonRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/pipeline/VeilFirstPersonRenderer.java
@@ -60,7 +60,7 @@ public final class VeilFirstPersonRenderer {
     public static void unbind() {
         // TODO update projection/modelview matrix
         ProfilerFiller profiler = Minecraft.getInstance().getProfiler();
-        boolean rendered = VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum());
+        boolean rendered = VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum(), false);
         ((RenderTargetExtension) Minecraft.getInstance().getMainRenderTarget()).veil$setWrapper(null);
 
         if (rendered) {

--- a/common/src/main/java/foundry/veil/mixin/pipeline/client/PipelineLevelRendererMixin.java
+++ b/common/src/main/java/foundry/veil/mixin/pipeline/client/PipelineLevelRendererMixin.java
@@ -113,7 +113,7 @@ public abstract class PipelineLevelRendererMixin implements LevelRendererExtensi
     @Inject(method = "renderLevel", at = @At("TAIL"))
     public void blit(CallbackInfo ci, @Local ProfilerFiller profiler) {
         if (!VeilLevelPerspectiveRenderer.isRenderingPerspective()) {
-            if (VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum())) {
+            if (VeilRenderSystem.drawLights(profiler, VeilRenderSystem.getCullingFrustum(), true)) {
                 VeilRenderSystem.compositeLights(profiler);
             } else {
                 AdvancedFbo.unbind();

--- a/common/src/main/resources/assets/veil/pinwheel/framebuffers/light_inscattering.json
+++ b/common/src/main/resources/assets/veil/pinwheel/framebuffers/light_inscattering.json
@@ -1,0 +1,10 @@
+{
+  "width": "q.screen_width / 4.0",
+  "height": "q.screen_height / 4.0",
+  "depth": true,
+  "filter": {
+    "blur": true
+  },
+  "autoClear": false,
+  "format": "RGB16F"
+}

--- a/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/area.json
+++ b/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/area.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "minecraft:depth_test",
-      "mode": "greater"
+      "mode": "notequal"
     },
     {
       "type": "minecraft:cull",

--- a/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/area.json
+++ b/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/area.json
@@ -16,11 +16,7 @@
     },
     {
       "type": "minecraft:depth_test",
-      "mode": "notequal"
-    },
-    {
-      "type": "minecraft:cull",
-      "face": "back"
+      "mode": "greater"
     },
     {
       "type": "minecraft:transparency",

--- a/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/inscattering/area.json
+++ b/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/inscattering/area.json
@@ -8,7 +8,7 @@
   "layers": [
     {
       "type": "veil:shader",
-      "name": "veil:light/point"
+      "name": "veil:light/inscattering/area"
     },
     {
       "type": "minecraft:write_mask",
@@ -16,7 +16,7 @@
     },
     {
       "type": "minecraft:depth_test",
-      "mode": "greater"
+      "mode": "notequal"
     },
     {
       "type": "minecraft:transparency",

--- a/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/inscattering/point.json
+++ b/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/inscattering/point.json
@@ -8,7 +8,7 @@
   "layers": [
     {
       "type": "veil:shader",
-      "name": "veil:light/point"
+      "name": "veil:light/inscattering/point"
     },
     {
       "type": "minecraft:write_mask",
@@ -16,7 +16,7 @@
     },
     {
       "type": "minecraft:depth_test",
-      "mode": "greater"
+      "mode": "notequal"
     },
     {
       "type": "minecraft:transparency",

--- a/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/point.json
+++ b/common/src/main/resources/assets/veil/pinwheel/rendertypes/light/point.json
@@ -16,7 +16,7 @@
     },
     {
       "type": "minecraft:depth_test",
-      "mode": "greater"
+      "mode": "notequal"
     },
     {
       "type": "minecraft:transparency",

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/include/space_helper.glsl
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/include/space_helper.glsl
@@ -142,3 +142,8 @@ vec4 screenToClipSpace(vec2 uv, float depth) {
 vec3 viewDirFromUv(vec2 uv) {
     return normalize(screenToLocalSpace(uv, 1.0).xyz);
 }
+
+float linearizeDepth(float depth) {
+    float z_n = 2.0 * depth - 1.0;
+    return 2.0 * VeilCamera.NearPlane * VeilCamera.FarPlane / (VeilCamera.FarPlane + VeilCamera.NearPlane - z_n * (VeilCamera.FarPlane - VeilCamera.NearPlane));
+}

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/include/space_helper.glsl
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/include/space_helper.glsl
@@ -143,7 +143,7 @@ vec3 viewDirFromUv(vec2 uv) {
     return normalize(screenToLocalSpace(uv, 1.0).xyz);
 }
 
-float linearizeDepth(float depth) {
-    float z_n = 2.0 * depth - 1.0;
-    return 2.0 * VeilCamera.NearPlane * VeilCamera.FarPlane / (VeilCamera.FarPlane + VeilCamera.NearPlane - z_n * (VeilCamera.FarPlane - VeilCamera.NearPlane));
+float depthSampleToWorldDepth(float depthSample) {
+    float f = depthSample * 2.0 - 1.0;
+    return 2.0 * VeilCamera.NearPlane * VeilCamera.FarPlane / (VeilCamera.FarPlane + VeilCamera.NearPlane - f * (VeilCamera.FarPlane - VeilCamera.NearPlane));
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.fsh
@@ -1,17 +1,34 @@
 uniform sampler2D DiffuseSampler0;
 uniform sampler2D DiffuseDepthSampler;
 uniform sampler2D LightSampler;
+uniform sampler2D LightInscatteringSampler;
 
 uniform vec4 ColorModulator;
+uniform vec2 ScreenSize;
 
 in vec2 texCoord;
 
 out vec4 fragColor;
 
+// Taken from https://github.com/amilajack/gaussian-blur/tree/master under MIT license
+
+vec4 blur9(sampler2D image, vec2 uv, vec2 resolution, vec2 direction) {
+    vec4 color = vec4(0.0);
+    vec2 off1 = vec2(1.3846153846) * direction;
+    vec2 off2 = vec2(3.2307692308) * direction;
+    color += texture2D(image, uv) * 0.2270270270;
+    color += texture2D(image, uv + (off1 / resolution)) * 0.3162162162;
+    color += texture2D(image, uv - (off1 / resolution)) * 0.3162162162;
+    color += texture2D(image, uv + (off2 / resolution)) * 0.0702702703;
+    color += texture2D(image, uv - (off2 / resolution)) * 0.0702702703;
+    return color;
+}
+
 void main() {
     vec4 main = texture(DiffuseSampler0, texCoord);
     float mainDepth = texture(DiffuseDepthSampler, texCoord).r;
-    vec3 light = texture(LightSampler, texCoord).rgb;
+    vec3 light = texture(LightSampler, texCoord).rgb + mix(
+            blur9(LightInscatteringSampler, texCoord, ScreenSize / 4.0, vec2(1, 0)), blur9(LightInscatteringSampler, texCoord, ScreenSize / 4.0, vec2(0, 1)), vec4(0.5)).rgb;
     fragColor = vec4(main.rgb + light, main.a);
     gl_FragDepth = mainDepth;
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.fsh
@@ -10,25 +10,31 @@ in vec2 texCoord;
 
 out vec4 fragColor;
 
-// Taken from https://github.com/amilajack/gaussian-blur/tree/master under MIT license
+#define BOXRADIUS 3
 
-vec4 blur9(sampler2D image, vec2 uv, vec2 resolution, vec2 direction) {
-    vec4 color = vec4(0.0);
-    vec2 off1 = vec2(1.3846153846) * direction;
-    vec2 off2 = vec2(3.2307692308) * direction;
-    color += texture2D(image, uv) * 0.2270270270;
-    color += texture2D(image, uv + (off1 / resolution)) * 0.3162162162;
-    color += texture2D(image, uv - (off1 / resolution)) * 0.3162162162;
-    color += texture2D(image, uv + (off2 / resolution)) * 0.0702702703;
-    color += texture2D(image, uv - (off2 / resolution)) * 0.0702702703;
-    return color;
+vec3 boxBlur(vec2 uv, vec2 size)
+{
+    int kernel_window_size = BOXRADIUS * 2 + 1;
+    int samples = kernel_window_size * kernel_window_size;
+
+    vec3 color = vec3(0);
+
+    float wsum = 0.0;
+    for (int ry = -BOXRADIUS; ry <= BOXRADIUS; ++ry)
+    for (int rx = -BOXRADIUS; rx <= BOXRADIUS; ++rx)
+    {
+        float w = 1.0;
+        wsum += w;
+        color += texture(LightInscatteringSampler, uv + vec2(rx, ry) / size).rgb * w;
+    }
+
+    return color/wsum;
 }
 
 void main() {
     vec4 main = texture(DiffuseSampler0, texCoord);
     float mainDepth = texture(DiffuseDepthSampler, texCoord).r;
-    vec3 light = texture(LightSampler, texCoord).rgb + mix(
-            blur9(LightInscatteringSampler, texCoord, ScreenSize / 4.0, vec2(1, 0)), blur9(LightInscatteringSampler, texCoord, ScreenSize / 4.0, vec2(0, 1)), vec4(0.5)).rgb;
+    vec3 light = texture(LightSampler, texCoord).rgb + boxBlur(texCoord, ScreenSize / 4.0).rgb;
     fragColor = vec4(main.rgb + light, main.a);
     gl_FragDepth = mainDepth;
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.json
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/core/composite.json
@@ -5,6 +5,10 @@
     "LightSampler": {
       "type": "framebuffer",
       "name": "veil:light"
+    },
+    "LightInscatteringSampler": {
+      "type": "framebuffer",
+      "name": "veil:light_inscattering"
     }
   }
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.fsh
@@ -5,11 +5,13 @@
 #include veil:voxel_shadow
 
 in mat4 lightMat;
+in mat4 invLightMat;
 in vec3 lightColor;
 in vec2 size;
 in float maxAngle;
 in float maxDistance;
 in float occluded;
+in float inscattering;
 
 uniform sampler2D AlbedoSampler;
 uniform sampler2D NormalSampler;
@@ -29,9 +31,10 @@ float sacos(float x)
 }
 
 struct AreaLightResult { vec3 position; float angle; };
-AreaLightResult closestPointOnPlaneAndAngle(vec3 point, mat4 planeMatrix, vec2 planeSize) {
+AreaLightResult closestPointOnPlaneAndAngle(vec3 point, mat4 planeMatrix, mat4 invPlaneMatrix, vec2 planeSize) {
     // no idea why i need to do this
     planeMatrix[3].xyz *= -1.0;
+    invPlaneMatrix[3].xyz *= -1.0;
     // transform the point to the plane's local space
     vec3 localSpacePoint = (planeMatrix * vec4(point, 1.0)).xyz;
     // clamp position
@@ -42,42 +45,90 @@ AreaLightResult closestPointOnPlaneAndAngle(vec3 point, mat4 planeMatrix, vec2 p
     float angle = sacos(dot(direction, vec3(0.0, 0.0, 1.0)));
 
     // transform back to global space
-    return AreaLightResult((inverse(planeMatrix) * vec4(localSpacePointOnPlane, 1.0)).xyz, angle);
+    return AreaLightResult((invPlaneMatrix * vec4(localSpacePointOnPlane, 1.0)).xyz, angle);
+}
+
+//Fog density
+#define DENSITY 2.6
+//Surface pass rate
+#define PASSTHROUGH 0.5
+
+#define STEPS 10.0
+
+float sdSphere( vec3 p, float r )
+{
+    return (length(p) - r) / DENSITY + PASSTHROUGH;
+}
+
+vec3 ray(vec3 dir, vec3 pos) {
+    //Output brightness
+    #define BRIGHTNESS 0.004
+
+    //Accumulative color
+    vec3 col = vec3(0.0);
+
+    //Glow raymarch loop
+    for(float i = 0.0; i<STEPS; i++)
+    {
+        //Glow density
+        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
+        vec3 lightPos = areaLightInfo.position;
+        float angle = areaLightInfo.angle;
+
+        float vol = sdSphere(pos - lightPos, 1.);
+        vec3 offset = lightPos - pos;
+        float atten = attenuate_no_cusp(length(offset), maxDistance);
+        float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
+        angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
+        //Step forward
+        pos += dir * vol;
+
+        //Add the sample color
+        col += (lightColor * inscattering * atten * angleFalloff) / vol;
+    }
+    //Tanh tonemapping
+    //https://mini.gmshaders.com/p/tonemaps
+    col = tanh(BRIGHTNESS * col);
+
+    return col;
 }
 
 void main() {
     vec2 screenUv = gl_FragCoord.xy / ScreenSize;
 
     vec4 albedoColor = texture(AlbedoSampler, screenUv);
-    if (albedoColor.a == 0) {
-        discard;
+    float diffuse = 0;
+    if (albedoColor.a > 0) {
+        vec3 normalVS = texture(NormalSampler, screenUv).xyz;
+        float depth = texture(DepthSampler, screenUv).r;
+        vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
+
+        // lighting calculation
+        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
+        vec3 lightPos = areaLightInfo.position;
+        float angle = areaLightInfo.angle;
+
+        vec3 offset = lightPos - pos;
+        vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
+        diffuse = (dot(normalVS, lightDirection) + 1.0) * 0.5;
+        diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
+        diffuse *= attenuate_no_cusp(length(offset), maxDistance);
+        // angle falloff
+        float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
+        angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
+        diffuse *= angleFalloff;
+        if (occluded > 0.5) {
+            vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
+            diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
+        }
     }
-
-    vec3 normalVS = texture(NormalSampler, screenUv).xyz;
-    float depth = texture(DepthSampler, screenUv).r;
-    vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
-
-    // lighting calculation
-    AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, size);
-    vec3 lightPos = areaLightInfo.position;
-    float angle = areaLightInfo.angle;
-
-    vec3 offset = lightPos - pos;
-    vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
-    float diffuse = (dot(normalVS, lightDirection) + 1.0) * 0.5;
-    diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
-    diffuse *= attenuate_no_cusp(length(offset), maxDistance);
-    // angle falloff
-    float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
-    angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
-    diffuse *= angleFalloff;
-    if (occluded > 0.5) {
-        vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
-        diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
+    vec3 volume = vec3(0);
+    if (inscattering > 0) {
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition);
     }
 
     float reflectivity = 0.05;
     vec3 diffuseColor = diffuse * lightColor;
 
-    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity, 1.0);
+    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity + volume, 1.0);
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.fsh
@@ -48,87 +48,38 @@ AreaLightResult closestPointOnPlaneAndAngle(vec3 point, mat4 planeMatrix, mat4 i
     return AreaLightResult((invPlaneMatrix * vec4(localSpacePointOnPlane, 1.0)).xyz, angle);
 }
 
-//Fog density
-#define DENSITY 2.6
-//Surface pass rate
-#define PASSTHROUGH 0.5
-
-#define STEPS 10.0
-
-float sdSphere( vec3 p, float r )
-{
-    return (length(p) - r) / DENSITY + PASSTHROUGH;
-}
-
-vec3 ray(vec3 dir, vec3 pos) {
-    //Output brightness
-    #define BRIGHTNESS 0.004
-
-    //Accumulative color
-    vec3 col = vec3(0.0);
-
-    //Glow raymarch loop
-    for(float i = 0.0; i<STEPS; i++)
-    {
-        //Glow density
-        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
-        vec3 lightPos = areaLightInfo.position;
-        float angle = areaLightInfo.angle;
-
-        float vol = sdSphere(pos - lightPos, 1.);
-        vec3 offset = lightPos - pos;
-        float atten = attenuate_no_cusp(length(offset), maxDistance);
-        float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
-        angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
-        //Step forward
-        pos += dir * vol;
-
-        //Add the sample color
-        col += (lightColor * inscattering * atten * angleFalloff) / vol;
-    }
-    //Tanh tonemapping
-    //https://mini.gmshaders.com/p/tonemaps
-    col = tanh(BRIGHTNESS * col);
-
-    return col;
-}
-
 void main() {
     vec2 screenUv = gl_FragCoord.xy / ScreenSize;
 
     vec4 albedoColor = texture(AlbedoSampler, screenUv);
-    float diffuse = 0;
-    if (albedoColor.a > 0) {
-        vec3 normalVS = texture(NormalSampler, screenUv).xyz;
-        float depth = texture(DepthSampler, screenUv).r;
-        vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
-
-        // lighting calculation
-        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
-        vec3 lightPos = areaLightInfo.position;
-        float angle = areaLightInfo.angle;
-
-        vec3 offset = lightPos - pos;
-        vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
-        diffuse = (dot(normalVS, lightDirection) + 1.0) * 0.5;
-        diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
-        diffuse *= attenuate_no_cusp(length(offset), maxDistance);
-        // angle falloff
-        float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
-        angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
-        diffuse *= angleFalloff;
-        if (occluded > 0.5) {
-            vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
-            diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
-        }
+    if (albedoColor.a == 0) {
+        discard;
     }
-    vec3 volume = vec3(0);
-    if (inscattering > 0) {
-        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition);
+    vec3 normalVS = texture(NormalSampler, screenUv).xyz;
+    float depth = texture(DepthSampler, screenUv).r;
+    vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
+
+    // lighting calculation
+    AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
+    vec3 lightPos = areaLightInfo.position;
+    float angle = areaLightInfo.angle;
+
+    vec3 offset = lightPos - pos;
+    vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
+    float diffuse = (dot(normalVS, lightDirection) + 1.0) * 0.5;
+    diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
+    diffuse *= attenuate_no_cusp(length(offset), maxDistance);
+    // angle falloff
+    float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
+    angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
+    diffuse *= angleFalloff;
+    if (occluded > 0.5) {
+        vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
+        diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
     }
 
     float reflectivity = 0.05;
     vec3 diffuseColor = diffuse * lightColor;
 
-    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity + volume, 1.0);
+    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity, 1.0);
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/area.vsh
@@ -7,13 +7,16 @@ layout (location = 6) in vec2 Size;
 layout (location = 7) in float NormalizedAngle;
 layout (location = 8) in float Distance;
 layout (location = 9) in float Occluded;
+layout (location = 10) in float Inscattering;
 
 out mat4 lightMat;
+out mat4 invLightMat;
 out vec3 lightColor;
 out vec2 size;
 out float maxAngle;
 out float maxDistance;
 out float occluded;
+out float inscattering;
 
 void main() {
     vec3 vertexPos = Position;
@@ -32,9 +35,11 @@ void main() {
     gl_Position = VeilCamera.ProjMat * VeilCamera.ViewMat * vec4(vertexPos - VeilCamera.CameraPosition, 1.0);
 
     lightMat = LightMatrix;
+    invLightMat = inverse(LightMatrix);
     lightColor = Color;
     size = Size;
     maxAngle = Angle;
     maxDistance = Distance;
     occluded = Occluded;
+    inscattering = Inscattering;
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.fsh
@@ -58,36 +58,34 @@ float sdSphere( vec3 p, float r )
     return (length(p) - r) / DENSITY + PASSTHROUGH;
 }
 
-vec3 ray(vec3 dir, vec3 pos, vec2 uv, float depth) {
+vec3 ray(vec3 dir, vec3 pos, vec3 fragPos) {
     //Output brightness
     #define BRIGHTNESS 0.004
 
     //Accumulative color
-    vec3 jitter = vec3(random(gl_FragCoord.xy + pos.xx), random(gl_FragCoord.xy + pos.yy), random(gl_FragCoord.xy + pos.zz)) - 0.5;
-    vec3 p = pos + jitter * 0.01;
     vec3 col = vec3(0.0);
     float d = 0;
-    float fov = getFov();
+    float fragDistance = distance(pos, fragPos);
 
     //Glow raymarch loop
     for(float i = 0.0; i<STEPS; i++)
     {
         //Glow density
-        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(p, lightMat, invLightMat, size);
+        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(pos, lightMat, invLightMat, size);
         vec3 lightPos = areaLightInfo.position;
         float angle = areaLightInfo.angle;
 
-        float vol = sdSphere(p - lightPos, 1.);
-        d += vol - (fov * pow(2 * length(uv) - 1, 2));
+        float vol = sdSphere(pos - lightPos, 1.);
+        d += vol;
 
-        vec3 offset = lightPos - p;
+        vec3 offset = lightPos - pos;
         float atten = attenuate_no_cusp(length(offset), maxDistance);
         float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
         angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
         //Step forward
-        p += dir * vol;
-        if ((depth - d) < 1.0) {
-            atten *= smoothstep(0.0, 1.0, (depth - d));
+        pos += dir * vol;
+        if (fragDistance - d < 1.0) {
+            atten *= smoothstep(0.0, 1.0, fragDistance - d);
         }
 
         //Add the sample color
@@ -105,8 +103,8 @@ void main() {
 
     vec3 volume = vec3(0);
     if (inscattering > 0.0) {
-        float d = linearizeDepth(texture(DepthSampler, screenUv).r);
-        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenUv, d);
+        float depth = texture(DepthSampler, screenUv).r;
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenToWorldSpace(screenUv, depth).xyz);
     }
 
     fragColor = vec4(volume, 1.0);

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.fsh
@@ -1,0 +1,113 @@
+#include veil:common
+#include veil:space_helper
+#include veil:color_utilities
+#include veil:light
+#include veil:voxel_shadow
+
+in mat4 lightMat;
+in mat4 invLightMat;
+in vec3 lightColor;
+in vec2 size;
+in float maxAngle;
+in float maxDistance;
+in float occluded;
+in float inscattering;
+
+uniform sampler2D DepthSampler;
+
+uniform vec2 ScreenSize;
+
+out vec4 fragColor;
+
+// acos approximation
+// faster and also doesn't flicker weirdly
+float sacos(float x)
+{
+    float y = abs(clamp(x, -1.0, 1.0));
+    float z = (-0.168577*y + 1.56723) * sqrt(1.0 - y);
+    return mix(0.5*3.1415927, z, sign(x));
+}
+
+struct AreaLightResult { vec3 position; float angle; };
+AreaLightResult closestPointOnPlaneAndAngle(vec3 point, mat4 planeMatrix, mat4 invPlaneMatrix, vec2 planeSize) {
+    // no idea why i need to do this
+    planeMatrix[3].xyz *= -1.0;
+    invPlaneMatrix[3].xyz *= -1.0;
+    // transform the point to the plane's local space
+    vec3 localSpacePoint = (planeMatrix * vec4(point, 1.0)).xyz;
+    // clamp position
+    vec3 localSpacePointOnPlane = vec3(clamp(localSpacePoint.xy, -planeSize, planeSize), 0);
+
+    // calculate the angles
+    vec3 direction = normalize(localSpacePoint - localSpacePointOnPlane);
+    float angle = sacos(dot(direction, vec3(0.0, 0.0, 1.0)));
+
+    // transform back to global space
+    return AreaLightResult((invPlaneMatrix * vec4(localSpacePointOnPlane, 1.0)).xyz, angle);
+}
+
+//Fog density
+#define DENSITY 2.6
+//Surface pass rate
+#define PASSTHROUGH 0.5
+
+#define STEPS 50.0
+
+float sdSphere( vec3 p, float r )
+{
+    return (length(p) - r) / DENSITY + PASSTHROUGH;
+}
+
+vec3 ray(vec3 dir, vec3 pos, vec2 uv, float depth) {
+    //Output brightness
+    #define BRIGHTNESS 0.004
+
+    //Accumulative color
+    vec3 jitter = vec3(random(gl_FragCoord.xy + pos.xx), random(gl_FragCoord.xy + pos.yy), random(gl_FragCoord.xy + pos.zz)) - 0.5;
+    vec3 p = pos + jitter * 0.01;
+    vec3 col = vec3(0.0);
+    float d = 0;
+    float fov = getFov();
+
+    //Glow raymarch loop
+    for(float i = 0.0; i<STEPS; i++)
+    {
+        //Glow density
+        AreaLightResult areaLightInfo = closestPointOnPlaneAndAngle(p, lightMat, invLightMat, size);
+        vec3 lightPos = areaLightInfo.position;
+        float angle = areaLightInfo.angle;
+
+        float vol = sdSphere(p - lightPos, 1.);
+        d += vol - (fov * pow(2 * length(uv) - 1, 2));
+
+        vec3 offset = lightPos - p;
+        float atten = attenuate_no_cusp(length(offset), maxDistance);
+        float angleFalloff = clamp(angle, 0.0, maxAngle) / maxAngle;
+        angleFalloff = smoothstep(1.0, 0.0, angleFalloff);
+        //Step forward
+        p += dir * vol;
+        if ((depth - d) < 1.0) {
+            atten *= smoothstep(0.0, 1.0, (depth - d));
+        }
+
+        //Add the sample color
+        col += (lightColor * inscattering * atten * angleFalloff) / vol;
+    }
+    //Tanh tonemapping
+    //https://mini.gmshaders.com/p/tonemaps
+    col = tanh(BRIGHTNESS * col);
+
+    return col;
+}
+
+void main() {
+    vec2 screenUv = gl_FragCoord.xy / (ScreenSize / 4.0);
+
+    vec3 volume = vec3(0);
+    if (inscattering > 0.0) {
+        float d = linearizeDepth(texture(DepthSampler, screenUv).r);
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenUv, d);
+    }
+
+    fragColor = vec4(volume, 1.0);
+}

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.json
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/area.json
@@ -1,0 +1,10 @@
+{
+  "vertex": "veil:light/area",
+  "fragment": "veil:light/inscattering/area",
+  "textures": {
+    "DepthSampler": {
+      "type": "framebuffer",
+      "name": "veil:light_inscattering:depth"
+    }
+  }
+}

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.fsh
@@ -1,0 +1,76 @@
+#include veil:common
+#include veil:space_helper
+#include veil:color_utilities
+#include veil:light
+#include veil:voxel_shadow
+
+in vec3 lightPos;
+in vec3 lightColor;
+in float radius;
+in float occluded;
+in float inscattering;
+
+uniform sampler2D DepthSampler;
+
+uniform vec2 ScreenSize;
+
+out vec4 fragColor;
+
+//Fog density
+#define DENSITY 2.6
+//Surface pass rate
+#define PASSTHROUGH 0.5
+
+#define STEPS 50.0
+
+float sdSphere( vec3 p, float r )
+{
+    return (length(p - lightPos) - r) / DENSITY + PASSTHROUGH;
+}
+
+vec3 ray(vec3 dir, vec3 pos, vec2 uv, float depth) {
+    //Output brightness
+    #define BRIGHTNESS 0.004
+
+    //Accumulative color
+    vec3 jitter = vec3(random(gl_FragCoord.xy + pos.xx), random(gl_FragCoord.xy + pos.yy), random(gl_FragCoord.xy + pos.zz)) - 0.5;
+    vec3 p = pos + jitter * 0.01;
+    vec3 col = vec3(0.0);
+    float d = 0;
+    float fov = getFov();
+
+    //Glow raymarch loop
+    for(float i = 0.0; i<STEPS; i++)
+    {
+        //Glow density
+        float vol = sdSphere(p, 1.);
+        vec3 offset = lightPos - p;
+        float atten = attenuate_no_cusp(length(offset), radius);
+        //Step forward
+        p += dir * vol;
+        d += vol - (fov * pow(2 * length(uv) - 1, 2));
+        if ((depth - d) < 1.0) {
+            atten *= smoothstep(0.0, 1.0, (depth - d));
+        }
+
+        //Add the sample color
+        col += (lightColor * inscattering * atten) / vol;
+    }
+    //Tanh tonemapping
+    //https://mini.gmshaders.com/p/tonemaps
+    col = tanh(BRIGHTNESS * col);
+
+    return col;
+}
+
+void main() {
+    vec2 screenUv = gl_FragCoord.xy / (ScreenSize / 4.0);
+
+    vec3 volume = vec3(0);
+    if (inscattering > 0.0) {
+        float d = linearizeDepth(texture(DepthSampler, screenUv).r);
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenUv, d);
+    }
+
+    fragColor = vec4(volume, 1.0);
+}

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.fsh
@@ -28,29 +28,28 @@ float sdSphere( vec3 p, float r )
     return (length(p - lightPos) - r) / DENSITY + PASSTHROUGH;
 }
 
-vec3 ray(vec3 dir, vec3 pos, vec2 uv, float depth) {
+vec3 ray(vec3 dir, vec3 pos, vec3 fragPos) {
     //Output brightness
     #define BRIGHTNESS 0.004
 
     //Accumulative color
-    vec3 jitter = vec3(random(gl_FragCoord.xy + pos.xx), random(gl_FragCoord.xy + pos.yy), random(gl_FragCoord.xy + pos.zz)) - 0.5;
-    vec3 p = pos + jitter * 0.01;
     vec3 col = vec3(0.0);
     float d = 0;
-    float fov = getFov();
+    float fragDistance = distance(pos, fragPos);
 
     //Glow raymarch loop
     for(float i = 0.0; i<STEPS; i++)
     {
         //Glow density
-        float vol = sdSphere(p, 1.);
-        vec3 offset = lightPos - p;
+        float vol = sdSphere(pos, 1.);
+        vec3 offset = lightPos - pos;
         float atten = attenuate_no_cusp(length(offset), radius);
         //Step forward
-        p += dir * vol;
-        d += vol - (fov * pow(2 * length(uv) - 1, 2));
-        if ((depth - d) < 1.0) {
-            atten *= smoothstep(0.0, 1.0, (depth - d));
+        pos += dir * vol;
+
+        d += vol;
+        if (fragDistance - d < 1.0) {
+            atten *= smoothstep(0.0, 1.0, fragDistance - d);
         }
 
         //Add the sample color
@@ -68,8 +67,8 @@ void main() {
 
     vec3 volume = vec3(0);
     if (inscattering > 0.0) {
-        float d = linearizeDepth(texture(DepthSampler, screenUv).r);
-        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenUv, d);
+        float depth = texture(DepthSampler, screenUv).r;
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition + VeilCamera.CameraBobOffset, screenToWorldSpace(screenUv, depth).xyz);
     }
 
     fragColor = vec4(volume, 1.0);

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.json
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/inscattering/point.json
@@ -1,0 +1,10 @@
+{
+  "vertex": "veil:light/point",
+  "fragment": "veil:light/inscattering/point",
+  "textures": {
+    "DepthSampler": {
+      "type": "framebuffer",
+      "name": "minecraft:main:depth"
+    }
+  }
+}

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.fsh
@@ -18,77 +18,31 @@ uniform vec2 ScreenSize;
 
 out vec4 fragColor;
 
-//Fog density
-#define DENSITY 2.6
-//Surface pass rate
-#define PASSTHROUGH 0.5
-
-#define STEPS 10.0
-
-float sdSphere( vec3 p, float r )
-{
-    return (length(p - lightPos) - r) / DENSITY + PASSTHROUGH;
-}
-
-float random(vec2 uv) {
-    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
-}
-
-vec3 ray(vec3 dir, vec3 pos) {
-    //Output brightness
-    #define BRIGHTNESS 0.004
-
-    //Accumulative color
-    vec3 col = vec3(0.0);
-
-    //Glow raymarch loop
-    for(float i = 0.0; i<STEPS; i++)
-    {
-        //Glow density
-        float vol = sdSphere(pos, 1.);
-        vec3 offset = lightPos - pos;
-        float atten = attenuate_no_cusp(length(offset), radius);
-        //Step forward
-        pos += dir * vol;
-
-        //Add the sample color
-        col += (lightColor * inscattering * atten) / vol;
-    }
-    //Tanh tonemapping
-    //https://mini.gmshaders.com/p/tonemaps
-    col = tanh(BRIGHTNESS * col);
-
-    return col;
-}
-
 void main() {
     vec2 screenUv = gl_FragCoord.xy / ScreenSize;
 
     vec4 albedoColor = texture(AlbedoSampler, screenUv);
-    float diffuse = 0;
-    if (albedoColor.a > 0) {
-        float depth = texture(DepthSampler, screenUv).r;
-        vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
 
-        // lighting calculation
-        vec3 offset = lightPos - pos;
-
-        vec3 normalVS = texture(NormalSampler, screenUv).xyz;
-        vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
-        diffuse = clamp(dot(normalVS, lightDirection), 0.0, 1.0);
-        diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
-        diffuse *= attenuate_no_cusp(length(offset), radius);
-        if (occluded > 0.5) {
-            vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
-            diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
-        }
+    if (albedoColor.a == 0) {
+        discard;
     }
-    vec3 volume = vec3(0);
-    if (inscattering > 0.0) {
-        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition);
+    float depth = texture(DepthSampler, screenUv).r;
+    vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
+
+    // lighting calculation
+    vec3 offset = lightPos - pos;
+    vec3 normalVS = texture(NormalSampler, screenUv).xyz;
+    vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
+    float diffuse = clamp(dot(normalVS, lightDirection), 0.0, 1.0);
+    diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
+    diffuse *= attenuate_no_cusp(length(offset), radius);
+
+    if (occluded > 0.5) {
+        vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
+        diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
     }
 
     float reflectivity = 0.05;
     vec3 diffuseColor = diffuse * lightColor;
-    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity + volume, 1.0);
+    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity, 1.0);
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.fsh
@@ -8,6 +8,7 @@ in vec3 lightPos;
 in vec3 lightColor;
 in float radius;
 in float occluded;
+in float inscattering;
 
 uniform sampler2D AlbedoSampler;
 uniform sampler2D NormalSampler;
@@ -17,31 +18,77 @@ uniform vec2 ScreenSize;
 
 out vec4 fragColor;
 
+//Fog density
+#define DENSITY 2.6
+//Surface pass rate
+#define PASSTHROUGH 0.5
+
+#define STEPS 10.0
+
+float sdSphere( vec3 p, float r )
+{
+    return (length(p - lightPos) - r) / DENSITY + PASSTHROUGH;
+}
+
+float random(vec2 uv) {
+    return fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 ray(vec3 dir, vec3 pos) {
+    //Output brightness
+    #define BRIGHTNESS 0.004
+
+    //Accumulative color
+    vec3 col = vec3(0.0);
+
+    //Glow raymarch loop
+    for(float i = 0.0; i<STEPS; i++)
+    {
+        //Glow density
+        float vol = sdSphere(pos, 1.);
+        vec3 offset = lightPos - pos;
+        float atten = attenuate_no_cusp(length(offset), radius);
+        //Step forward
+        pos += dir * vol;
+
+        //Add the sample color
+        col += (lightColor * inscattering * atten) / vol;
+    }
+    //Tanh tonemapping
+    //https://mini.gmshaders.com/p/tonemaps
+    col = tanh(BRIGHTNESS * col);
+
+    return col;
+}
+
 void main() {
     vec2 screenUv = gl_FragCoord.xy / ScreenSize;
 
     vec4 albedoColor = texture(AlbedoSampler, screenUv);
-    if (albedoColor.a == 0) {
-        discard;
+    float diffuse = 0;
+    if (albedoColor.a > 0) {
+        float depth = texture(DepthSampler, screenUv).r;
+        vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
+
+        // lighting calculation
+        vec3 offset = lightPos - pos;
+
+        vec3 normalVS = texture(NormalSampler, screenUv).xyz;
+        vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
+        diffuse = clamp(dot(normalVS, lightDirection), 0.0, 1.0);
+        diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
+        diffuse *= attenuate_no_cusp(length(offset), radius);
+        if (occluded > 0.5) {
+            vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
+            diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
+        }
     }
-
-    float depth = texture(DepthSampler, screenUv).r;
-    vec3 pos = screenToWorldSpace(screenUv, depth).xyz;
-
-    // lighting calculation
-    vec3 offset = lightPos - pos;
-
-    vec3 normalVS = texture(NormalSampler, screenUv).xyz;
-    vec3 lightDirection = normalize((VeilCamera.ViewMat * vec4(offset, 0.0)).xyz);
-    float diffuse = clamp(dot(normalVS, lightDirection), 0.0, 1.0);
-    diffuse = (diffuse + MINECRAFT_AMBIENT_LIGHT) / (1.0 + MINECRAFT_AMBIENT_LIGHT);
-    diffuse *= attenuate_no_cusp(length(offset), radius);
-    if (occluded > 0.5) {
-        vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
-        diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, lightPos);
+    vec3 volume = vec3(0);
+    if (inscattering > 0.0) {
+        volume = ray(viewDirFromUv(screenUv), VeilCamera.CameraPosition);
     }
 
     float reflectivity = 0.05;
     vec3 diffuseColor = diffuse * lightColor;
-    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity, 1.0);
+    fragColor = vec4(albedoColor.rgb * diffuseColor * (1.0 - reflectivity) + diffuseColor * reflectivity + volume, 1.0);
 }

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/point.vsh
@@ -5,11 +5,13 @@ layout (location = 1) in vec3 LightPosition;
 layout (location = 2) in vec3 Color;
 layout (location = 3) in float Distance;
 layout (location = 4) in float Occluded;
+layout (location = 5) in float Inscattering;
 
 out vec3 lightPos;
 out vec3 lightColor;
 out float radius;
 out float occluded;
+out float inscattering;
 
 void main() {
     vec3 size = Position * Distance;
@@ -22,4 +24,5 @@ void main() {
     lightColor = Color;
     radius = Distance;
     occluded = Occluded;
+    inscattering = Inscattering;
 }


### PR DESCRIPTION
In-scattering gives Veil's lights a better sense of volume by simulating some volumetric fog around the lights. This PR also adds light guides to the lights to help show the radius for point lights and the angle/size/distance for area lights. Let me know if any changes need to be made!
Example of in-scattering:
<img width="639" height="479" alt="A screenshot of a campfire with a light using in-scattering around it." src="https://github.com/user-attachments/assets/75ae22b1-3222-4b15-918d-b32853e76b72" />
Example of light guides:
<img width="1920" height="1080" alt="A screenshot of the light guides on an area light" src="https://github.com/user-attachments/assets/03ca3a80-4200-443a-bfde-a906fd76a7d0" />