### PR TITLE
Add DDA voxel shadow occlusion for directional lights

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/render/light/data/DirectionalLightData.java
+++ b/common/src/main/java/foundry/veil/api/client/render/light/data/DirectionalLightData.java
@@ -4,6 +4,7 @@ import foundry.veil.api.client.color.Colorc;
 import foundry.veil.api.client.editor.EditorAttributeProvider;
 import foundry.veil.api.client.registry.LightTypeRegistry;
 import foundry.veil.api.client.render.CullFrustum;
+import foundry.veil.api.client.render.light.DDALightData;
 import imgui.ImGui;
 import net.minecraft.client.Camera;
 import org.joml.Vector3f;
@@ -14,12 +15,14 @@ import org.joml.Vector3fc;
  *
  * @since 2.0.0
  */
-public class DirectionalLightData extends LightData implements EditorAttributeProvider {
+public class DirectionalLightData extends LightData implements EditorAttributeProvider, DDALightData {
 
     protected final Vector3f direction;
+    protected boolean occlusionEnabled;
 
     public DirectionalLightData() {
         this.direction = new Vector3f(0.0F, -1.0F, 0.0F);
+        this.occlusionEnabled = false;
     }
 
     /**
@@ -92,6 +95,12 @@ public class DirectionalLightData extends LightData implements EditorAttributePr
         return this;
     }
 
+    public DirectionalLightData setOcclusionEnabled(boolean occlusionEnabled) {
+        this.occlusionEnabled = occlusionEnabled;
+        this.markDirty();
+        return this;
+    }
+
     @Override
     public boolean isVisible(CullFrustum frustum) {
         return true;
@@ -117,5 +126,14 @@ public class DirectionalLightData extends LightData implements EditorAttributePr
         }
         ImGui.sameLine(0, ImGui.getStyle().getItemInnerSpacingX());
         ImGui.text("direction");
+
+        if (ImGui.checkbox("Occluded", this.occlusionEnabled)) {
+            this.setOcclusionEnabled(!this.occlusionEnabled);
+        }
+    }
+
+    @Override
+    public boolean isOcclusionEnabled() {
+        return this.occlusionEnabled;
     }
 }

--- a/common/src/main/java/foundry/veil/impl/client/render/light/DirectionalLightRenderer.java
+++ b/common/src/main/java/foundry/veil/impl/client/render/light/DirectionalLightRenderer.java
@@ -7,6 +7,7 @@ import foundry.veil.Veil;
 import foundry.veil.api.client.color.Colorc;
 import foundry.veil.api.client.render.CullFrustum;
 import foundry.veil.api.client.render.light.data.DirectionalLightData;
+import foundry.veil.api.client.render.light.renderer.DDALightRenderer;
 import foundry.veil.api.client.render.light.renderer.LightRenderHandle;
 import foundry.veil.api.client.render.light.renderer.LightRenderer;
 import foundry.veil.api.client.render.light.renderer.LightTypeRenderer;
@@ -17,13 +18,14 @@ import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.ApiStatus;
 import org.joml.Vector3f;
+import org.joml.Vector3fc;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
 @ApiStatus.Internal
-public class DirectionalLightRenderer implements LightTypeRenderer<DirectionalLightData> {
+public class DirectionalLightRenderer implements DDALightRenderer<DirectionalLightData> {
 
     private static final Vector3f DIRECTION = new Vector3f();
     private static final ResourceLocation RENDER_TYPE = Veil.veilPath("light/directional");
@@ -115,6 +117,12 @@ public class DirectionalLightRenderer implements LightTypeRenderer<DirectionalLi
                 lightDirection.upload();
             }
 
+            Uniform occluded = shader.getUniform("Occluded");
+            if (occluded != null) {
+                occluded.set(light.isOcclusionEnabled() ? 1f : 0f);
+                occluded.upload();
+            }
+
             this.vertexArray.draw();
         }
     }
@@ -133,6 +141,19 @@ public class DirectionalLightRenderer implements LightTypeRenderer<DirectionalLi
     public void free() {
         this.vertexArray.close();
         this.freed = true;
+    }
+
+    @Override
+    public void uploadVoxelGridUniforms(int voxelGridTexture, Vector3fc voxelGridOrigin) {
+        RenderType renderType = VeilRenderType.get(RENDER_TYPE);
+        if (renderType == null) {
+            return;
+        }
+
+        ResourceLocation veilShaderId = VeilRenderType.getShards(renderType).veilShaderId();
+        if (veilShaderId != null) {
+            DDALightRenderer.uploadVoxelGridUniforms(veilShaderId, voxelGridTexture, voxelGridOrigin);
+        }
     }
 
     private class LightHandle implements LightRenderHandle<DirectionalLightData> {

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/directional.fsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/directional.fsh
@@ -1,14 +1,17 @@
 #include veil:common
 #include veil:space_helper
 #include veil:color_utilities
+#include veil:voxel_shadow
 
 in vec2 texCoord;
 
 uniform sampler2D AlbedoSampler;
 uniform sampler2D NormalSampler;
+uniform sampler2D DepthSampler;
 
 uniform vec3 LightColor;
 uniform vec3 LightDirection;
+uniform float Occluded;
 
 out vec4 fragColor;
 
@@ -23,6 +26,12 @@ void main() {
 
     // lighting calculation
     float diffuse = clamp(smoothstep(-0.2, 0.2, -dot(normalVS, lightDirectionVS)), 0.0, 1.0);
+
+    if (Occluded > 0.5) {
+        vec3 normalWS = normalize((VeilCamera.IViewMat * vec4(normalVS, 0.0)).xyz);
+        vec3 pos = screenToWorldSpace(texCoord, texture(DepthSampler, texCoord).r).xyz;
+        diffuse *= voxelshadowVisibility(pos + normalWS * 0.01, pos - LightDirection * 50);
+    }
 
     float reflectivity = 0.05;
     vec3 diffuseColor = diffuse * LightColor;

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/directional.json
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/light/directional.json
@@ -3,6 +3,10 @@
   "fragment": "veil:light/directional",
   "textures": {
     "AlbedoSampler": "veil:dynamic_buffer/albedo",
-    "NormalSampler": "veil:dynamic_buffer/normal"
+    "NormalSampler": "veil:dynamic_buffer/normal",
+    "DepthSampler": {
+      "type": "framebuffer",
+      "name": "minecraft:main:depth"
+    }
   }
 }


### PR DESCRIPTION
Voxel shadow occlusion is missing for directional lights, so this PR implements `DDALightRenderer` for the directional light renderer, which makes it feel more like a real sun.