### PR TITLE
Optimize Quasar particle using instancing

### DIFF
--- a/common/src/main/java/foundry/veil/VeilClient.java
+++ b/common/src/main/java/foundry/veil/VeilClient.java
@@ -40,6 +40,7 @@ public class VeilClient {
         });
         VeilEventPlatform.INSTANCE.onVeilRendererAvailable(renderer -> {
             RESOURCE_MANAGER.addVeilLoaders(renderer);
+            RenderStyleRegistry.initRenderStyles();
 //            glEnable(GL_DEPTH_CLAMP); // TODO add config option
         });
 

--- a/common/src/main/java/foundry/veil/api/client/render/VeilRenderSystem.java
+++ b/common/src/main/java/foundry/veil/api/client/render/VeilRenderSystem.java
@@ -29,6 +29,7 @@ import foundry.veil.api.client.render.texture.VeilPreloadedTexture;
 import foundry.veil.api.compat.SodiumCompat;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
 import foundry.veil.api.flare.modifier.RandomnessController;
+import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.ext.LevelRendererExtension;
 import foundry.veil.ext.TextureManagerExtension;
 import foundry.veil.ext.VertexBufferExtension;
@@ -1251,6 +1252,7 @@ public final class VeilRenderSystem {
         glDeleteVertexArrays(screenQuadVao);
         MemoryUtil.memFree(emptySamplers);
         SHADER_BUFFER_CACHE.free();
+        RenderStyleRegistry.freeRenderStyles();
     }
 
     @ApiStatus.Internal

--- a/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
+++ b/common/src/main/java/foundry/veil/api/client/render/rendertype/VeilRenderType.java
@@ -60,17 +60,16 @@ public final class VeilRenderType extends RenderType {
     }
 
     private static final ShaderStateShard PARTICLE = VeilRenderBridge.shaderState(Veil.veilPath("quasar/particle"));
-    private static final ShaderStateShard PARTICLE_ADDITIVE = VeilRenderBridge.shaderState(Veil.veilPath("quasar/particle_additive"));
 
     private static final BiFunction<ResourceLocation, Boolean, RenderType> QUASAR_PARTICLE = Util.memoize((texture, additive) -> {
         CompositeState state = RenderType.CompositeState.builder()
-                .setShaderState(additive ? PARTICLE_ADDITIVE : PARTICLE)
+                .setShaderState(PARTICLE)
                 .setTextureState(new TextureStateShard(texture, false, false))
                 .setTransparencyState(additive ? ADDITIVE_TRANSPARENCY : TRANSLUCENT_TRANSPARENCY)
                 .setLightmapState(LIGHTMAP)
                 .setWriteMaskState(COLOR_DEPTH_WRITE)
                 .createCompositeState(false);
-        return create(Veil.MODID + ":quasar_particle", VeilVertexFormat.QUASAR_PARTICLE, VertexFormat.Mode.QUADS, SMALL_BUFFER_SIZE, false, false, state);
+        return create(Veil.MODID + ":quasar_particle", VeilVertexFormat.QUASAR_PARTICLE, VertexFormat.Mode.QUADS, SMALL_BUFFER_SIZE, false, true, state);
     });
     private static final BiFunction<ResourceLocation, Boolean, RenderType> QUASAR_TRAIL = Util.memoize((texture, additive) -> {
         CompositeState state = CompositeState.builder()

--- a/common/src/main/java/foundry/veil/api/client/render/vertex/VeilVertexFormat.java
+++ b/common/src/main/java/foundry/veil/api/client/render/vertex/VeilVertexFormat.java
@@ -23,9 +23,9 @@ public class VeilVertexFormat {
             .build();
     public static final VertexFormat QUASAR_PARTICLE = VertexFormat.builder()
             .add("Position", POSITION)
-            .add("UV0", UV0)
-            .add("Color", COLOR)
-            .add("UV2", UV2)
+            //.add("UV0", UV0)
+            //.add("Color", COLOR)
+            //.add("UV2", UV2)
             .add("Normal", NORMAL)
             .build();
 

--- a/common/src/main/java/foundry/veil/api/client/render/vertex/VeilVertexFormat.java
+++ b/common/src/main/java/foundry/veil/api/client/render/vertex/VeilVertexFormat.java
@@ -23,9 +23,6 @@ public class VeilVertexFormat {
             .build();
     public static final VertexFormat QUASAR_PARTICLE = VertexFormat.builder()
             .add("Position", POSITION)
-            //.add("UV0", UV0)
-            //.add("Color", COLOR)
-            //.add("UV2", UV2)
             .add("Normal", NORMAL)
             .build();
 

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -238,7 +238,6 @@ public class ParticleEmitter {
         }
 
         Vec3 projectedView = camera.getPosition();
-        Vector3f renderOffset = new Vector3f();
         RenderType lastRenderType = null;
         VertexConsumer builder = null;
 
@@ -248,12 +247,6 @@ public class ParticleEmitter {
             particle.render(partialTicks);
 
             renderData.renderTrails(matrixStack, bufferSource, projectedView, LightTexture.FULL_BRIGHT, partialTicks);
-
-            Vector3dc renderPosition = renderData.getRenderPosition();
-            renderOffset.set(
-                    (float) (renderPosition.x() - projectedView.x()),
-                    (float) (renderPosition.y() - projectedView.y()),
-                    (float) (renderPosition.z() - projectedView.z()));
 
             RenderType renderType = renderData.getRenderType();
             if (!renderType.equals(lastRenderType)) {
@@ -265,9 +258,9 @@ public class ParticleEmitter {
                     builder = sprite.wrap(builder);
                 }
             }
-
-            renderStyle.render(matrixStack, particle, renderData, renderOffset, builder, 1, partialTicks);
         }
+        renderStyle.render(matrixStack, this.particles, camera, builder, 1, partialTicks);
+
         renderStyle.clear();
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -259,7 +259,7 @@ public class ParticleEmitter {
                 }
             }
         }
-        renderStyle.render(matrixStack, this.particles, camera, builder, 1, partialTicks);
+        renderStyle.render(this.particles, camera);
 
         renderStyle.clear();
     }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -1,6 +1,5 @@
 package foundry.veil.api.quasar.particle;
 
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import foundry.veil.Veil;
 import foundry.veil.api.TickTaskScheduler;
 import foundry.veil.api.client.render.MatrixStack;
@@ -12,8 +11,6 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
@@ -238,8 +235,6 @@ public class ParticleEmitter {
         }
 
         Vec3 projectedView = camera.getPosition();
-        RenderType lastRenderType = null;
-        VertexConsumer builder = null;
 
         for (QuasarParticle particle : this.particles) {
             RenderData renderData = particle.getRenderData();
@@ -247,17 +242,6 @@ public class ParticleEmitter {
             particle.render(partialTicks);
 
             renderData.renderTrails(matrixStack, bufferSource, projectedView, LightTexture.FULL_BRIGHT, partialTicks);
-
-            RenderType renderType = renderData.getRenderType();
-            if (!renderType.equals(lastRenderType)) {
-                lastRenderType = renderType;
-                builder = bufferSource.getBuffer(renderType);
-
-                TextureAtlasSprite sprite = renderData.getAtlasSprite();
-                if (sprite != null) {
-                    builder = sprite.wrap(builder);
-                }
-            }
         }
         renderStyle.render(this.particles, camera);
 

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -11,7 +11,6 @@ import foundry.veil.api.client.render.vertex.VertexArrayBuilder;
 import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.api.util.CodecUtil;
 import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.world.phys.Vec3;
@@ -55,10 +54,10 @@ public abstract class RenderStyle {
 
         this.vertexArray = VertexArray.create();
         this.vertexArray.upload(this.createMesh(), VertexArray.DrawUsage.STATIC);
-        this.instanceVBO = this.vertexArray.getOrCreateBuffer(0);
+        this.instanceVBO = this.vertexArray.getOrCreateBuffer(2);
 
         VertexArrayBuilder builder = this.vertexArray.editFormat();
-        builder.defineVertexBuffer(0, this.instanceVBO, 0, bufferSize, 1);
+        builder.defineVertexBuffer(2, this.instanceVBO, 0, bufferSize, 1);
         this.setupBufferState(builder);
     }
 
@@ -82,15 +81,12 @@ public abstract class RenderStyle {
     }
 
     /**
-     * Draws a single particle.
+     * Draws a list of particles using a batched VertexArray.
      *
-     * @param matrixStack  The current stack of matrix transformations
      * @param particles    A list of currently active particles
-     * @param renderOffset The offset from the camera to draw the particle at
-     * @param builder      The vertex consumer to draw into
-     * @param partialTicks The percentage from last tick to this tick
+     * @param camera       The camera to use to render the particles
      */
-    public void render(MatrixStack matrixStack, List<QuasarParticle> particles, Camera camera, VertexConsumer builder, double ageModifier, float partialTicks) {
+    public void render(List<QuasarParticle> particles, Camera camera) {
         if (particles.isEmpty()) return;
 
         RenderType renderType = this.getRenderType(particles.getFirst(), particles.getFirst().getRenderData());
@@ -184,48 +180,11 @@ public abstract class RenderStyle {
 
                 // RIGHT
                 new Vector3f(1, -1, 1), new Vector3f(1, 1, 1), new Vector3f(1, 1, -1), new Vector3f(1, -1, -1)};
-        private static final float[] CUBE_UVS = {0, 0, 0, 1, 1, 1, 1, 0};
         private static final float[] CUBE_NORMALS = {0, 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 0};
-        private static final Vector3f POS = new Vector3f();
 
         public Cube() {
-            super(Float.BYTES * 24 + Short.BYTES * 2);
+            super(Float.BYTES * 25 + Short.BYTES * 2);
         }
-
-        //@Override
-        //public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-            /*
-            for (int i = 0; i < 6; i++) {
-                for (int j = 0; j < 4; j++) {
-                    POS.set(CUBE_POSITIONS[i * 4 + j]);
-                    QuasarParticleData data = particle.getData();
-                    if (POS.z < 0 && data.velocityStretchFactor() != 0.0f) {
-                        POS.z *= 1 + data.velocityStretchFactor();
-                    }
-                    POS.rotateX(rotation.x())
-                            .rotateY(rotation.y())
-                            .rotateZ(rotation.z())
-                            .mul((float) (renderData.getRenderRadius() * ageModifier))
-                            .add(renderOffset);
-
-                    float u = CUBE_UVS[j * 2];
-                    float v = CUBE_UVS[j * 2 + 1];
-
-                    if (spriteData != null) {
-                        u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
-                        v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
-                    }
-
-                    builder.addVertex(matrix4f, POS.x, POS.y, POS.z);
-                    builder.setUv(u, v);
-                    builder.setColor(renderData.getRed(), renderData.getGreen(), renderData.getBlue(), renderData.getAlpha());
-                    builder.setLight(renderData.getPackedLight());
-                    builder.setNormal(CUBE_NORMALS[i * 3], CUBE_NORMALS[i * 3 + 1], CUBE_NORMALS[i * 3 + 2]);
-                }
-
-            }
-             */
-        //}
 
         @Override
         protected MeshData createMesh() {
@@ -245,14 +204,15 @@ public abstract class RenderStyle {
 
         @Override
         protected void setupBufferState(VertexArrayBuilder builder) {
-            builder.setVertexAttribute(2, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
-            builder.setVertexAttribute(3, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
-            builder.setVertexAttribute(4, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
-            builder.setVertexAttribute(5, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
-            builder.setVertexAttribute(6, 0, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // UV0 min
-            builder.setVertexAttribute(7, 0, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 18); // UV0 max
-            builder.setVertexAttribute(8, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 20); // Color
-            builder.setVertexAttribute(9, 0, 2, VertexArrayBuilder.DataType.SHORT, false, Float.BYTES * 24); // UV2 / Light
+            builder.setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
+            builder.setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
+            builder.setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
+            builder.setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
+            builder.setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
+            builder.setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
+            builder.setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
+            builder.setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
+            builder.setVertexAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, false, Float.BYTES * 25); // UV2 / Light
         }
 
         @Override
@@ -265,17 +225,18 @@ public abstract class RenderStyle {
             Vector3f renderOffset = new Vector3f();
             Vector3dc renderPosition = renderData.getRenderPosition();
             renderOffset.set(
-                    (float) (renderPosition.x()),
-                    (float) (renderPosition.y()),
-                    (float) (renderPosition.z()));
+                    (float) (renderPosition.x() - projectedView.x),
+                    (float) (renderPosition.y() - projectedView.y),
+                    (float) (renderPosition.z() - projectedView.z));
 
-            Matrix4f transformationMatrix = new Matrix4f()
-                    //.rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()))
-                    //.scale(renderData.getRenderRadius())
+            Matrix4f transformationMatrix = new Matrix4f().identity()
+                    .rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()))
                     .translate(renderOffset.x, renderOffset.y, renderOffset.z);
             transformationMatrix.get(buffer.position(), buffer);
 
             buffer.position(buffer.position() + Float.BYTES * 16);
+
+            buffer.putFloat(renderData.getRenderRadius());
 
             float uMin = 0;
             float vMin = 0;
@@ -284,8 +245,8 @@ public abstract class RenderStyle {
             if (spriteData != null) {
                 uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
                 uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
-                vMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
-                vMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
+                vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
+                vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
             }
             buffer.putFloat(uMin);
             buffer.putFloat(vMin);

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -18,6 +18,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
 import org.joml.*;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.NativeResource;
 
 import java.lang.Math;
 import java.nio.ByteBuffer;
@@ -32,7 +33,7 @@ import static org.lwjgl.system.MemoryUtil.memAddress;
  *
  * @author Ocelot, BL
  */
-public abstract class RenderStyle {
+public abstract class RenderStyle implements NativeResource {
 
     public static final Codec<RenderStyle> CODEC = CodecUtil.registryOrLegacyCodec(RenderStyleRegistry.REGISTRY);
 
@@ -41,15 +42,18 @@ public abstract class RenderStyle {
     private final int bufferSize;
     protected int maxParticles;
 
-    public static final int MAX_PARTICLES = 400;
+    public static final int MIN_PARTICLES = 400;
 
     public RenderStyle(int bufferSize) {
         this.bufferSize = bufferSize;
         this.maxParticles = 0;
     }
 
+    /**
+     * Called after the Veil renderer is available, sets up anything necessary for rendering.
+     */
     public void init() {
-        if (bufferSize < 0) {
+        if (bufferSize <= 0) {
             return;
         }
 
@@ -107,19 +111,19 @@ public abstract class RenderStyle {
             } else {
                 this.maxParticles = (int) Math.max(Math.ceil(this.maxParticles / 2.0), visibleParticles.size() * 1.5);
             }
-            glBufferData(GL_ARRAY_BUFFER, (long) this.maxParticles * this.bufferSize, GL_STREAM_DRAW);
+            glBufferData(GL_ARRAY_BUFFER, (long) this.maxParticles * this.bufferSize, GL_STATIC_DRAW);
         }
 
         try (MemoryStack stack = MemoryStack.stackPush()) {
             int pointer = 0;
             long offset = 0;
-            ByteBuffer dataBuffer = stack.malloc(Math.min(MAX_PARTICLES, visibleParticles.size()) * this.bufferSize);
+            ByteBuffer dataBuffer = stack.malloc(Math.min(MIN_PARTICLES, visibleParticles.size()) * this.bufferSize);
             for (QuasarParticle particle : visibleParticles) {
                 dataBuffer.position((pointer++) * this.bufferSize);
 
                 this.putBufferData(particle, camera, dataBuffer);
 
-                if (pointer >= MAX_PARTICLES) {
+                if (pointer >= MIN_PARTICLES) {
                     dataBuffer.rewind();
                     glBufferSubData(GL_ARRAY_BUFFER, offset, dataBuffer);
                     offset += dataBuffer.capacity();
@@ -158,15 +162,33 @@ public abstract class RenderStyle {
         return VeilRenderType.quasarParticle(RenderData.BLANK, additive);
     }
 
+    @Override
+    public void free() {
+        this.vertexArray.free();
+
+    }
+
+    /**
+     * @return The MeshData to use for each particle.
+     */
     protected abstract MeshData createMesh();
 
+    /**
+     * Set up the vertex attribute arrays to use for each particle.
+     * @param builder The builder associated with the VertexArray
+     */
     protected abstract void setupBufferState(VertexArrayBuilder builder);
 
+    /**
+     * Put information about each particle into the vertex attribute array.
+     * @param particle The particle being loaded
+     * @param camera The camera rendering the particles
+     * @param buffer The buffer of the current VertexArray
+     */
     protected abstract void putBufferData(QuasarParticle particle, Camera camera, ByteBuffer buffer);
 
     @ApiStatus.Internal
     public static final class Cube extends RenderStyle {
-
         private static final Vector3fc[] CUBE_POSITIONS = {
                 // TOP
                 new Vector3f(1, 1, -1), new Vector3f(1, 1, 1), new Vector3f(-1, 1, 1), new Vector3f(-1, 1, -1),
@@ -184,7 +206,8 @@ public abstract class RenderStyle {
                 new Vector3f(-1, -1, -1), new Vector3f(-1, 1, -1), new Vector3f(-1, 1, 1), new Vector3f(-1, -1, 1),
 
                 // RIGHT
-                new Vector3f(1, -1, 1), new Vector3f(1, 1, 1), new Vector3f(1, 1, -1), new Vector3f(1, -1, -1)};
+                new Vector3f(1, -1, 1), new Vector3f(1, 1, 1), new Vector3f(1, 1, -1), new Vector3f(1, -1, -1)
+        };
         private static final float[] CUBE_NORMALS = {0, 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 0};
 
         public Cube() {
@@ -209,15 +232,15 @@ public abstract class RenderStyle {
 
         @Override
         protected void setupBufferState(VertexArrayBuilder builder) {
-            builder.setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
-            builder.setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
-            builder.setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
-            builder.setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
-            builder.setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
-            builder.setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
-            builder.setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
-            builder.setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
-            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, Float.BYTES * 25); // UV2 / Light
+            builder. setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
+            builder. setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
+            builder. setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
+            builder. setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
+            builder. setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
+            builder. setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
+            builder. setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
+            builder. setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
+            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT,                  Float.BYTES * 25); // UV2 / Light
         }
 
         @Override
@@ -248,10 +271,10 @@ public abstract class RenderStyle {
             float uMax = 1;
             float vMax = 1;
             if (spriteData != null) {
-                //uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
-                //uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
-                //vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
-                //vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
+                uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
+                uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
+                vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
+                vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
             }
             buffer.putFloat(uMin);
             buffer.putFloat(vMin);
@@ -276,65 +299,10 @@ public abstract class RenderStyle {
                 // plane from -1 to 1 on Y axis and -1 to 1 on X axis
                 new Vector3f(1, -1, 0), new Vector3f(1, 1, 0), new Vector3f(-1, 1, 0), new Vector3f(-1, -1, 0),
         };
-        private static final float[] PLANE_UVS = {0, 0, 0, 1, 1, 1, 1, 0};
-        private static final Vector3f POS = new Vector3f();
-        private static final Vector3f NORMAL = new Vector3f();
 
         public Billboard() {
             super(Float.BYTES * 25 + Short.BYTES * 2);
         }
-
-        //@Override
-        //public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-        //    Matrix4f matrix4f = matrixStack.position();
-        //    Vector3fc rotation = renderData.getRenderRotation();
-//
-        //    Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation();
-        //    SpriteData spriteData = renderData.getSpriteData();
-//
-        //    int red = (int) (renderData.getRed() * 255.0F) & 0xFF;
-        //    int green = (int) (renderData.getGreen() * 255.0F) & 0xFF;
-        //    int blue = (int) (renderData.getBlue() * 255.0F) & 0xFF;
-        //    int alpha = (int) (renderData.getAlpha() * 255.0F) & 0xFF;
-//
-        //    NORMAL.set(0, 0, -1);
-        //    if (particle.getData().faceVelocity()) {
-        //        NORMAL.rotateX(rotation.x())
-        //                .rotateY(rotation.y())
-        //                .rotateZ(rotation.z());
-        //    }
-//
-        //    // turn quat into pitch and yaw
-        //    for (int j = 0; j < 4; j++) {
-        //        POS.set(PLANE_POSITIONS[j]);
-        //        if (particle.getData().velocityStretchFactor() > 0f) {
-        //            POS.set(POS.x * (1 + particle.getData().velocityStretchFactor()), POS.y, POS.z);
-        //        }
-        //        if (particle.getData().faceVelocity()) {
-        //            POS.rotateX(rotation.x())
-        //                    .rotateY(rotation.y())
-        //                    .rotateZ(rotation.z());
-        //        }
-//      //          vec = vec.xRot(lerpedPitch).yRot(lerpedYaw).zRot(lerpedRoll);
-        //        faceCameraRotation.transform(POS).mul((float) (renderData.getRenderRadius() * ageModifier)).add(renderOffset);
-//
-        //        float u = PLANE_UVS[j * 2];
-        //        float v = PLANE_UVS[j * 2 + 1];
-        //        if (spriteData != null) {
-        //            u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
-        //            v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
-        //        }
-//      //              if (particle.sprite != null) {
-//      //                  u1 = u;
-//      //                  v1 = v;
-//      //              }
-        //        builder.addVertex(matrix4f, POS.x, POS.y, POS.z);
-        //        builder.setUv(u, v);
-        //        builder.setColor(red, green, blue, alpha);
-        //        builder.setLight(renderData.getPackedLight());
-        //        builder.setNormal(NORMAL.x, NORMAL.y, NORMAL.z);
-        //    }
-        //}
 
         @Override
         protected MeshData createMesh() {
@@ -352,15 +320,15 @@ public abstract class RenderStyle {
 
         @Override
         protected void setupBufferState(VertexArrayBuilder builder) {
-            builder.setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
-            builder.setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
-            builder.setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
-            builder.setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
-            builder.setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
-            builder.setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
-            builder.setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
-            builder.setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
-            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, Float.BYTES * 25); // UV2 / Light
+            builder. setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
+            builder. setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
+            builder. setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
+            builder. setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
+            builder. setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
+            builder. setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
+            builder. setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
+            builder. setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
+            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT,        Float.BYTES * 25); // UV2 / Light
         }
 
         @Override

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -1,38 +1,75 @@
 package foundry.veil.api.quasar.particle;
 
-import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
 import com.mojang.serialization.Codec;
 import foundry.veil.api.client.render.MatrixStack;
 import foundry.veil.api.client.render.rendertype.VeilRenderType;
-import foundry.veil.api.quasar.data.QuasarParticleData;
+import foundry.veil.api.client.render.vertex.VeilVertexFormat;
+import foundry.veil.api.client.render.vertex.VertexArray;
+import foundry.veil.api.client.render.vertex.VertexArrayBuilder;
 import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.api.util.CodecUtil;
+import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
-import org.joml.Matrix4f;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
+import org.lwjgl.system.MemoryStack;
+
+import java.lang.Math;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.lwjgl.opengl.GL15C.*;
+import static org.lwjgl.opengl.GL15C.GL_ARRAY_BUFFER;
+import static org.lwjgl.system.MemoryUtil.memAddress;
 
 /**
  * Defines how a particle emitter renders a set of particles.
  *
  * @author Ocelot, BL
  */
-public interface RenderStyle {
+public abstract class RenderStyle {
 
-    Codec<RenderStyle> CODEC = CodecUtil.registryOrLegacyCodec(RenderStyleRegistry.REGISTRY);
+    public static final Codec<RenderStyle> CODEC = CodecUtil.registryOrLegacyCodec(RenderStyleRegistry.REGISTRY);
+
+    private VertexArray vertexArray;
+    private int instanceVBO;
+    private final int bufferSize;
+    protected int maxParticles;
+
+    public static final int MAX_PARTICLES = 400;
+
+    public RenderStyle(int bufferSize) {
+        this.bufferSize = bufferSize;
+        this.maxParticles = 0;
+    }
+
+    public void init() {
+        if (bufferSize < 0) {
+            return;
+        }
+
+        this.vertexArray = VertexArray.create();
+        this.vertexArray.upload(this.createMesh(), VertexArray.DrawUsage.STATIC);
+        this.instanceVBO = this.vertexArray.getOrCreateBuffer(0);
+
+        VertexArrayBuilder builder = this.vertexArray.editFormat();
+        builder.defineVertexBuffer(0, this.instanceVBO, 0, bufferSize, 1);
+        this.setupBufferState(builder);
+    }
 
     /**
      * Called before rendering any particles. This will not be fired if the emitter has no particles.
      *
-     * @param particleCount The number of particles that will be rendered with {@link #render(MatrixStack, QuasarParticle, RenderData, Vector3fc, VertexConsumer, double, float)}
+     * @param particleCount The number of particles that will be rendered with {@link #render(MatrixStack, List, Vector3fc, VertexConsumer, double, float)}
      * @return Whether the particles are allowed to render
      * @since 1.3.0
      */
-    default boolean setup(int particleCount) {
+    public boolean setup(int particleCount) {
         return true;
     }
 
@@ -41,20 +78,63 @@ public interface RenderStyle {
      *
      * @since 1.3.0
      */
-    default void clear() {
+    public void clear() {
     }
 
     /**
      * Draws a single particle.
      *
      * @param matrixStack  The current stack of matrix transformations
-     * @param particle     The particle to render
-     * @param renderData   The render data associated with that particle
+     * @param particles    A list of currently active particles
      * @param renderOffset The offset from the camera to draw the particle at
      * @param builder      The vertex consumer to draw into
      * @param partialTicks The percentage from last tick to this tick
      */
-    void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks);
+    public void render(MatrixStack matrixStack, List<QuasarParticle> particles, Camera camera, VertexConsumer builder, double ageModifier, float partialTicks) {
+        if (particles.isEmpty()) return;
+
+        RenderType renderType = this.getRenderType(particles.getFirst(), particles.getFirst().getRenderData());
+        if (renderType == null) {
+            return;
+        }
+
+        RenderSystem.glBindBuffer(GL_ARRAY_BUFFER, this.instanceVBO);
+
+        if (particles.size() > this.maxParticles) {
+            if (this.maxParticles < 100) {
+                this.maxParticles = 100;
+            } else {
+                this.maxParticles = (int) Math.max(Math.ceil(this.maxParticles / 2.0), particles.size() * 1.5);
+            }
+            glBufferData(GL_ARRAY_BUFFER, (long) this.maxParticles * this.bufferSize, GL_STREAM_DRAW);
+        }
+
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            int pointer = 0;
+            long offset = 0;
+            ByteBuffer dataBuffer = stack.malloc(Math.min(MAX_PARTICLES, particles.size()) * this.bufferSize);
+            for (QuasarParticle particle : particles) {
+                dataBuffer.position((pointer++) * this.bufferSize);
+
+                this.putBufferData(particle, camera, dataBuffer);
+
+                if (pointer >= MAX_PARTICLES) {
+                    dataBuffer.rewind();
+                    glBufferSubData(GL_ARRAY_BUFFER, offset, dataBuffer);
+                    offset += dataBuffer.capacity();
+                    pointer = 0;
+                }
+            }
+
+            if (pointer > 0) {
+                dataBuffer.rewind();
+                nglBufferSubData(GL_ARRAY_BUFFER, offset, (long) pointer * this.bufferSize, memAddress(dataBuffer));
+            }
+        }
+
+        this.vertexArray.bind();
+        this.vertexArray.drawInstancedWithRenderType(renderType, particles.size());
+    }
 
     /**
      * @return The render type to use for the specified particle.
@@ -62,7 +142,7 @@ public interface RenderStyle {
      * @see RenderData#markDirty()
      * @since 1.3.0
      */
-    default RenderType getRenderType(QuasarParticle particle, RenderData renderData) {
+    public RenderType getRenderType(QuasarParticle particle, RenderData renderData) {
         boolean additive = renderData.isAdditive();
         TextureAtlasSprite atlasSprite = renderData.getAtlasSprite();
         if (atlasSprite != null) {
@@ -77,8 +157,14 @@ public interface RenderStyle {
         return VeilRenderType.quasarParticle(RenderData.BLANK, additive);
     }
 
+    protected abstract MeshData createMesh();
+
+    protected abstract void setupBufferState(VertexArrayBuilder builder);
+
+    protected abstract void putBufferData(QuasarParticle particle, Camera camera, ByteBuffer buffer);
+
     @ApiStatus.Internal
-    final class Cube implements RenderStyle {
+    public static final class Cube extends RenderStyle {
 
         private static final Vector3fc[] CUBE_POSITIONS = {
                 // TOP
@@ -102,12 +188,13 @@ public interface RenderStyle {
         private static final float[] CUBE_NORMALS = {0, 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 0};
         private static final Vector3f POS = new Vector3f();
 
-        @Override
-        public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-            Matrix4f matrix4f = matrixStack.position();
-            Vector3fc rotation = renderData.getRenderRotation();
-            SpriteData spriteData = renderData.getSpriteData();
+        public Cube() {
+            super(Float.BYTES * 24 + Short.BYTES * 2);
+        }
 
+        //@Override
+        //public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
+            /*
             for (int i = 0; i < 6; i++) {
                 for (int j = 0; j < 4; j++) {
                     POS.set(CUBE_POSITIONS[i * 4 + j]);
@@ -135,12 +222,89 @@ public interface RenderStyle {
                     builder.setLight(renderData.getPackedLight());
                     builder.setNormal(CUBE_NORMALS[i * 3], CUBE_NORMALS[i * 3 + 1], CUBE_NORMALS[i * 3 + 2]);
                 }
+
             }
+             */
+        //}
+
+        @Override
+        protected MeshData createMesh() {
+            BufferBuilder builder = RenderSystem.renderThreadTesselator().begin(VertexFormat.Mode.QUADS, VeilVertexFormat.QUASAR_PARTICLE);
+
+            for (int i = 0; i < 6; i++) {
+                for (int j = 0; j < 4; j++) {
+                    Vector3fc pos = CUBE_POSITIONS[i * 4 + j];
+
+                    builder.addVertex(pos.x(), pos.y(), pos.z());
+                    builder.setNormal(CUBE_NORMALS[i * 3], CUBE_NORMALS[i * 3 + 1], CUBE_NORMALS[i * 3 + 2]);
+                }
+            }
+
+            return builder.buildOrThrow();
+        }
+
+        @Override
+        protected void setupBufferState(VertexArrayBuilder builder) {
+            builder.setVertexAttribute(2, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
+            builder.setVertexAttribute(3, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
+            builder.setVertexAttribute(4, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
+            builder.setVertexAttribute(5, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
+            builder.setVertexAttribute(6, 0, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // UV0 min
+            builder.setVertexAttribute(7, 0, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 18); // UV0 max
+            builder.setVertexAttribute(8, 0, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 20); // Color
+            builder.setVertexAttribute(9, 0, 2, VertexArrayBuilder.DataType.SHORT, false, Float.BYTES * 24); // UV2 / Light
+        }
+
+        @Override
+        protected void putBufferData(QuasarParticle particle, Camera camera, ByteBuffer buffer) {
+            RenderData renderData = particle.getRenderData();
+            Vector3fc rotation = renderData.getRenderRotation();
+            SpriteData spriteData = renderData.getSpriteData();
+
+            Vec3 projectedView = camera.getPosition();
+            Vector3f renderOffset = new Vector3f();
+            Vector3dc renderPosition = renderData.getRenderPosition();
+            renderOffset.set(
+                    (float) (renderPosition.x()),
+                    (float) (renderPosition.y()),
+                    (float) (renderPosition.z()));
+
+            Matrix4f transformationMatrix = new Matrix4f()
+                    //.rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()))
+                    //.scale(renderData.getRenderRadius())
+                    .translate(renderOffset.x, renderOffset.y, renderOffset.z);
+            transformationMatrix.get(buffer.position(), buffer);
+
+            buffer.position(buffer.position() + Float.BYTES * 16);
+
+            float uMin = 0;
+            float vMin = 0;
+            float uMax = 1;
+            float vMax = 1;
+            if (spriteData != null) {
+                uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
+                uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
+                vMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
+                vMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
+            }
+            buffer.putFloat(uMin);
+            buffer.putFloat(vMin);
+            buffer.putFloat(uMax);
+            buffer.putFloat(vMax);
+
+            buffer.putFloat(renderData.getRed());
+            buffer.putFloat(renderData.getGreen());
+            buffer.putFloat(renderData.getBlue());
+            buffer.putFloat(renderData.getAlpha());
+
+            int packedLight = renderData.getPackedLight();
+            buffer.putShort((short) (packedLight & '\uffff'));
+            buffer.putShort((short) (packedLight >> 16 & '\uffff'));
         }
     }
 
     @ApiStatus.Internal
-    final class Billboard implements RenderStyle {
+    public static final class Billboard extends RenderStyle {
 
         private static final Vector3fc[] PLANE_POSITIONS = {
                 // plane from -1 to 1 on Y axis and -1 to 1 on X axis
@@ -150,56 +314,75 @@ public interface RenderStyle {
         private static final Vector3f POS = new Vector3f();
         private static final Vector3f NORMAL = new Vector3f();
 
+        public Billboard() {
+            super(0);
+        }
+
+        //@Override
+        //public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
+        //    Matrix4f matrix4f = matrixStack.position();
+        //    Vector3fc rotation = renderData.getRenderRotation();
+//
+        //    Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation();
+        //    SpriteData spriteData = renderData.getSpriteData();
+//
+        //    int red = (int) (renderData.getRed() * 255.0F) & 0xFF;
+        //    int green = (int) (renderData.getGreen() * 255.0F) & 0xFF;
+        //    int blue = (int) (renderData.getBlue() * 255.0F) & 0xFF;
+        //    int alpha = (int) (renderData.getAlpha() * 255.0F) & 0xFF;
+//
+        //    NORMAL.set(0, 0, -1);
+        //    if (particle.getData().faceVelocity()) {
+        //        NORMAL.rotateX(rotation.x())
+        //                .rotateY(rotation.y())
+        //                .rotateZ(rotation.z());
+        //    }
+//
+        //    // turn quat into pitch and yaw
+        //    for (int j = 0; j < 4; j++) {
+        //        POS.set(PLANE_POSITIONS[j]);
+        //        if (particle.getData().velocityStretchFactor() > 0f) {
+        //            POS.set(POS.x * (1 + particle.getData().velocityStretchFactor()), POS.y, POS.z);
+        //        }
+        //        if (particle.getData().faceVelocity()) {
+        //            POS.rotateX(rotation.x())
+        //                    .rotateY(rotation.y())
+        //                    .rotateZ(rotation.z());
+        //        }
+//      //          vec = vec.xRot(lerpedPitch).yRot(lerpedYaw).zRot(lerpedRoll);
+        //        faceCameraRotation.transform(POS).mul((float) (renderData.getRenderRadius() * ageModifier)).add(renderOffset);
+//
+        //        float u = PLANE_UVS[j * 2];
+        //        float v = PLANE_UVS[j * 2 + 1];
+        //        if (spriteData != null) {
+        //            u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
+        //            v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
+        //        }
+//      //              if (particle.sprite != null) {
+//      //                  u1 = u;
+//      //                  v1 = v;
+//      //              }
+        //        builder.addVertex(matrix4f, POS.x, POS.y, POS.z);
+        //        builder.setUv(u, v);
+        //        builder.setColor(red, green, blue, alpha);
+        //        builder.setLight(renderData.getPackedLight());
+        //        builder.setNormal(NORMAL.x, NORMAL.y, NORMAL.z);
+        //    }
+        //}
+
         @Override
-        public void render(MatrixStack matrixStack, QuasarParticle particle, RenderData renderData, Vector3fc renderOffset, VertexConsumer builder, double ageModifier, float partialTicks) {
-            Matrix4f matrix4f = matrixStack.position();
-            Vector3fc rotation = renderData.getRenderRotation();
+        protected MeshData createMesh() {
+            return null;
+        }
 
-            Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation();
-            SpriteData spriteData = renderData.getSpriteData();
+        @Override
+        protected void setupBufferState(VertexArrayBuilder builder) {
 
-            int red = (int) (renderData.getRed() * 255.0F) & 0xFF;
-            int green = (int) (renderData.getGreen() * 255.0F) & 0xFF;
-            int blue = (int) (renderData.getBlue() * 255.0F) & 0xFF;
-            int alpha = (int) (renderData.getAlpha() * 255.0F) & 0xFF;
+        }
 
-            NORMAL.set(0, 0, -1);
-            if (particle.getData().faceVelocity()) {
-                NORMAL.rotateX(rotation.x())
-                        .rotateY(rotation.y())
-                        .rotateZ(rotation.z());
-            }
+        @Override
+        protected void putBufferData(QuasarParticle particle, Camera camera, ByteBuffer buffer) {
 
-            // turn quat into pitch and yaw
-            for (int j = 0; j < 4; j++) {
-                POS.set(PLANE_POSITIONS[j]);
-                if (particle.getData().velocityStretchFactor() > 0f) {
-                    POS.set(POS.x * (1 + particle.getData().velocityStretchFactor()), POS.y, POS.z);
-                }
-                if (particle.getData().faceVelocity()) {
-                    POS.rotateX(rotation.x())
-                            .rotateY(rotation.y())
-                            .rotateZ(rotation.z());
-                }
-//                vec = vec.xRot(lerpedPitch).yRot(lerpedYaw).zRot(lerpedRoll);
-                faceCameraRotation.transform(POS).mul((float) (renderData.getRenderRadius() * ageModifier)).add(renderOffset);
-
-                float u = PLANE_UVS[j * 2];
-                float v = PLANE_UVS[j * 2 + 1];
-                if (spriteData != null) {
-                    u = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), u);
-                    v = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), v);
-                }
-//                    if (particle.sprite != null) {
-//                        u1 = u;
-//                        v1 = v;
-//                    }
-                builder.addVertex(matrix4f, POS.x, POS.y, POS.z);
-                builder.setUv(u, v);
-                builder.setColor(red, green, blue, alpha);
-                builder.setLight(renderData.getPackedLight());
-                builder.setNormal(NORMAL.x, NORMAL.y, NORMAL.z);
-            }
         }
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -3,7 +3,7 @@ package foundry.veil.api.quasar.particle;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.serialization.Codec;
-import foundry.veil.api.client.render.MatrixStack;
+import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.rendertype.VeilRenderType;
 import foundry.veil.api.client.render.vertex.VeilVertexFormat;
 import foundry.veil.api.client.render.vertex.VertexArray;
@@ -11,6 +11,7 @@ import foundry.veil.api.client.render.vertex.VertexArrayBuilder;
 import foundry.veil.api.quasar.registry.RenderStyleRegistry;
 import foundry.veil.api.util.CodecUtil;
 import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.world.phys.Vec3;
@@ -64,7 +65,7 @@ public abstract class RenderStyle {
     /**
      * Called before rendering any particles. This will not be fired if the emitter has no particles.
      *
-     * @param particleCount The number of particles that will be rendered with {@link #render(MatrixStack, List, Vector3fc, VertexConsumer, double, float)}
+     * @param particleCount The number of particles that will be rendered with {@link #render(List, Camera)}
      * @return Whether the particles are allowed to render
      * @since 1.3.0
      */
@@ -89,18 +90,22 @@ public abstract class RenderStyle {
     public void render(List<QuasarParticle> particles, Camera camera) {
         if (particles.isEmpty()) return;
 
-        RenderType renderType = this.getRenderType(particles.getFirst(), particles.getFirst().getRenderData());
+        RenderType renderType = particles.getFirst().getRenderData().getRenderType();
         if (renderType == null) {
             return;
         }
 
+        // Perform frustum culling for each particle
+        List<QuasarParticle> visibleParticles = particles.stream().filter(particle -> VeilRenderSystem.getCullingFrustum().testSphere(particle.getPosition(), particle.getRenderData().getRenderRadius())).toList();
+        if (visibleParticles.isEmpty()) return;
+
         RenderSystem.glBindBuffer(GL_ARRAY_BUFFER, this.instanceVBO);
 
-        if (particles.size() > this.maxParticles) {
+        if (visibleParticles.size() > this.maxParticles) {
             if (this.maxParticles < 100) {
                 this.maxParticles = 100;
             } else {
-                this.maxParticles = (int) Math.max(Math.ceil(this.maxParticles / 2.0), particles.size() * 1.5);
+                this.maxParticles = (int) Math.max(Math.ceil(this.maxParticles / 2.0), visibleParticles.size() * 1.5);
             }
             glBufferData(GL_ARRAY_BUFFER, (long) this.maxParticles * this.bufferSize, GL_STREAM_DRAW);
         }
@@ -108,8 +113,8 @@ public abstract class RenderStyle {
         try (MemoryStack stack = MemoryStack.stackPush()) {
             int pointer = 0;
             long offset = 0;
-            ByteBuffer dataBuffer = stack.malloc(Math.min(MAX_PARTICLES, particles.size()) * this.bufferSize);
-            for (QuasarParticle particle : particles) {
+            ByteBuffer dataBuffer = stack.malloc(Math.min(MAX_PARTICLES, visibleParticles.size()) * this.bufferSize);
+            for (QuasarParticle particle : visibleParticles) {
                 dataBuffer.position((pointer++) * this.bufferSize);
 
                 this.putBufferData(particle, camera, dataBuffer);
@@ -129,7 +134,7 @@ public abstract class RenderStyle {
         }
 
         this.vertexArray.bind();
-        this.vertexArray.drawInstancedWithRenderType(renderType, particles.size());
+        this.vertexArray.drawInstancedWithRenderType(renderType, visibleParticles.size());
     }
 
     /**
@@ -212,7 +217,7 @@ public abstract class RenderStyle {
             builder.setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
             builder.setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
             builder.setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
-            builder.setVertexAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, false, Float.BYTES * 25); // UV2 / Light
+            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, Float.BYTES * 25); // UV2 / Light
         }
 
         @Override
@@ -229,9 +234,9 @@ public abstract class RenderStyle {
                     (float) (renderPosition.y() - projectedView.y),
                     (float) (renderPosition.z() - projectedView.z));
 
-            Matrix4f transformationMatrix = new Matrix4f().identity()
-                    .rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()))
-                    .translate(renderOffset.x, renderOffset.y, renderOffset.z);
+            Matrix4f transformationMatrix = new Matrix4f()
+                    .translate(renderOffset.x, renderOffset.y, renderOffset.z)
+                    .rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()));
             transformationMatrix.get(buffer.position(), buffer);
 
             buffer.position(buffer.position() + Float.BYTES * 16);
@@ -243,10 +248,10 @@ public abstract class RenderStyle {
             float uMax = 1;
             float vMax = 1;
             if (spriteData != null) {
-                uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
-                uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
-                vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
-                vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
+                //uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
+                //uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
+                //vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
+                //vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
             }
             buffer.putFloat(uMin);
             buffer.putFloat(vMin);
@@ -259,8 +264,8 @@ public abstract class RenderStyle {
             buffer.putFloat(renderData.getAlpha());
 
             int packedLight = renderData.getPackedLight();
-            buffer.putShort((short) (packedLight & '\uffff'));
-            buffer.putShort((short) (packedLight >> 16 & '\uffff'));
+            buffer.putShort((short) ((packedLight & 65535)));
+            buffer.putShort((short) ((packedLight >> 16 & 65535)));
         }
     }
 
@@ -276,7 +281,7 @@ public abstract class RenderStyle {
         private static final Vector3f NORMAL = new Vector3f();
 
         public Billboard() {
-            super(0);
+            super(Float.BYTES * 25 + Short.BYTES * 2);
         }
 
         //@Override
@@ -333,17 +338,78 @@ public abstract class RenderStyle {
 
         @Override
         protected MeshData createMesh() {
-            return null;
+            BufferBuilder builder = RenderSystem.renderThreadTesselator().begin(VertexFormat.Mode.QUADS, VeilVertexFormat.QUASAR_PARTICLE);
+
+            for (int j = 0; j < 4; j++) {
+                Vector3fc pos = PLANE_POSITIONS[j];
+
+                builder.addVertex(pos.x(), pos.y(), pos.z());
+                builder.setNormal(0, 0, -1);
+            }
+
+            return builder.buildOrThrow();
         }
 
         @Override
         protected void setupBufferState(VertexArrayBuilder builder) {
-
+            builder.setVertexAttribute(2,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, 0               ); // Model Matrix[0]
+            builder.setVertexAttribute(3,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 4 ); // Model Matrix[1]
+            builder.setVertexAttribute(4,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 8 ); // Model Matrix[2]
+            builder.setVertexAttribute(5,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 12); // Model Matrix[3]
+            builder.setVertexAttribute(6,  2, 1, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 16); // Scale
+            builder.setVertexAttribute(7,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 17); // UV0 min
+            builder.setVertexAttribute(8,  2, 2, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 19); // UV0 max
+            builder.setVertexAttribute(9,  2, 4, VertexArrayBuilder.DataType.FLOAT, false, Float.BYTES * 21); // Color
+            builder.setVertexIAttribute(10, 2, 2, VertexArrayBuilder.DataType.SHORT, Float.BYTES * 25); // UV2 / Light
         }
 
         @Override
         protected void putBufferData(QuasarParticle particle, Camera camera, ByteBuffer buffer) {
+            RenderData renderData = particle.getRenderData();
+            Quaternionf faceCameraRotation = Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation().get(new Quaternionf());
+            Vector3fc rotation = renderData.getRenderRotation();
+            SpriteData spriteData = renderData.getSpriteData();
 
+            Vec3 projectedView = camera.getPosition();
+            Vector3f renderOffset = new Vector3f();
+            Vector3dc renderPosition = renderData.getRenderPosition();
+            renderOffset.set(
+                    (float) (renderPosition.x() - projectedView.x),
+                    (float) (renderPosition.y() - projectedView.y),
+                    (float) (renderPosition.z() - projectedView.z));
+
+            Matrix4f transformationMatrix = new Matrix4f()
+                    .translate(renderOffset.x, renderOffset.y, renderOffset.z)
+                    .rotate(faceCameraRotation.rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()));
+            transformationMatrix.get(buffer.position(), buffer);
+
+            buffer.position(buffer.position() + Float.BYTES * 16);
+
+            buffer.putFloat(renderData.getRenderRadius());
+
+            float uMin = 0;
+            float vMin = 0;
+            float uMax = 1;
+            float vMax = 1;
+            if (spriteData != null) {
+                uMin = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMin);
+                uMax = spriteData.u(renderData.getRenderAge(), renderData.getAgePercent(), uMax);
+                vMin = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMin);
+                vMax = spriteData.v(renderData.getRenderAge(), renderData.getAgePercent(), vMax);
+            }
+            buffer.putFloat(uMin);
+            buffer.putFloat(vMin);
+            buffer.putFloat(uMax);
+            buffer.putFloat(vMax);
+
+            buffer.putFloat(renderData.getRed());
+            buffer.putFloat(renderData.getGreen());
+            buffer.putFloat(renderData.getBlue());
+            buffer.putFloat(renderData.getAlpha());
+
+            int packedLight = renderData.getPackedLight();
+            buffer.putShort((short) ((packedLight & 65535)));
+            buffer.putShort((short) ((packedLight >> 16 & 65535)));
         }
     }
 }

--- a/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
@@ -18,7 +18,7 @@ public class RenderStyleRegistry {
     public static final Registry<RenderStyle> REGISTRY = PROVIDER.asVanillaRegistry();
 
     public static final RegistryObject<RenderStyle.Cube> CUBE = register("cube", new RenderStyle.Cube());
-    public static final RegistryObject<RenderStyle.Cube> BILLBOARD = register("billboard", new RenderStyle.Cube());
+    public static final RegistryObject<RenderStyle.Billboard> BILLBOARD = register("billboard", new RenderStyle.Billboard());
 
     @ApiStatus.Internal
     public static void bootstrap() {

--- a/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
@@ -29,6 +29,11 @@ public class RenderStyleRegistry {
         REGISTRY.entrySet().forEach(e -> e.getValue().init());
     }
 
+    @ApiStatus.Internal
+    public static void freeRenderStyles() {
+        REGISTRY.entrySet().forEach(e -> e.getValue().free());
+    }
+
     private static <T extends RenderStyle> RegistryObject<T> register(String name, T shape) {
         return PROVIDER.register(name, () -> shape);
     }

--- a/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/registry/RenderStyleRegistry.java
@@ -18,10 +18,15 @@ public class RenderStyleRegistry {
     public static final Registry<RenderStyle> REGISTRY = PROVIDER.asVanillaRegistry();
 
     public static final RegistryObject<RenderStyle.Cube> CUBE = register("cube", new RenderStyle.Cube());
-    public static final RegistryObject<RenderStyle.Billboard> BILLBOARD = register("billboard", new RenderStyle.Billboard());
+    public static final RegistryObject<RenderStyle.Cube> BILLBOARD = register("billboard", new RenderStyle.Cube());
 
     @ApiStatus.Internal
     public static void bootstrap() {
+    }
+
+    @ApiStatus.Internal
+    public static void initRenderStyles() {
+        REGISTRY.entrySet().forEach(e -> e.getValue().init());
     }
 
     private static <T extends RenderStyle> RegistryObject<T> register(String name, T shape) {

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
@@ -24,15 +24,15 @@ out vec4 vertexColor;
 out vec4 lightmapColor;
 
 void main() {
-    vec4 WorldPosition = (ParticleMat * vec4(Position * Scale, 1.0) + vec4(VeilCamera.CameraBobOffset, 0));
-    gl_Position = ProjMat * ModelViewMat * WorldPosition;
+    vec4 WorldPosition = ModelViewMat * ParticleMat * vec4(Position * Scale, 1.0);
+    gl_Position = ProjMat * WorldPosition;
     vertexDistance = length(WorldPosition.xyz);
     vec2 uvs[4];
     uvs[0] = UV0Min,
     uvs[1] = vec2(UV0Min.x, UV0Max.y),
     uvs[2] = UV0Max,
     uvs[3] = vec2(UV0Max.x, UV0Min.y);
-    texCoord0 = uvs[gl_VertexID];
+    texCoord0 = uvs[gl_VertexID % 4];
     #ifdef VEIL_LIGHT_UV
     // #veil:light_uv
     vec2 texCoord2 = vec2(UV2 / 256.0);

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
@@ -1,12 +1,15 @@
 #include veil:fog
+#veil:buffer veil:camera VeilCamera
 
 layout(location = 0) in vec3 Position;
-layout(location = 1) in vec2 UV0;
-layout(location = 2) in vec4 Color;
-layout(location = 3) in ivec2 UV2;
-#ifdef VEIL_NORMAL
-layout(location = 4) in vec3 Normal;
-#endif
+//#ifdef VEIL_NORMAL
+layout(location = 1) in vec3 Normal;
+//#endif
+layout(location = 2) in mat4 ParticleMat;
+layout(location = 6) in vec2 UV0Min;
+layout(location = 7) in vec2 UV0Max;
+layout(location = 8) in vec4 Color;
+layout(location = 9) in ivec2 UV2;
 
 uniform sampler2D Sampler2;
 
@@ -22,10 +25,15 @@ out vec4 vertexColor;
 out vec4 lightmapColor;
 
 void main() {
-    vec4 WorldPosition = ModelViewMat * vec4(Position, 1.0);
+    vec4 WorldPosition = VeilCamera.ViewMat * vec4(Position, 1.0);
     gl_Position = ProjMat * WorldPosition;
     vertexDistance = length(WorldPosition.xyz);
-    texCoord0 = UV0;
+    vec2 uvs[4];
+    uvs[0] = UV0Min,
+    uvs[1] = vec2(UV0Min.x, UV0Max.y),
+    uvs[2] = UV0Max,
+    uvs[3] = vec2(UV0Max.x, UV0Min.y);
+    texCoord0 = uvs[gl_VertexID];
     #ifdef VEIL_LIGHT_UV
     // #veil:light_uv
     vec2 texCoord2 = vec2(UV2 / 256.0);

--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
@@ -2,14 +2,13 @@
 #veil:buffer veil:camera VeilCamera
 
 layout(location = 0) in vec3 Position;
-//#ifdef VEIL_NORMAL
 layout(location = 1) in vec3 Normal;
-//#endif
 layout(location = 2) in mat4 ParticleMat;
-layout(location = 6) in vec2 UV0Min;
-layout(location = 7) in vec2 UV0Max;
-layout(location = 8) in vec4 Color;
-layout(location = 9) in ivec2 UV2;
+layout(location = 6) in float Scale;
+layout(location = 7) in vec2 UV0Min;
+layout(location = 8) in vec2 UV0Max;
+layout(location = 9) in vec4 Color;
+layout(location = 10) in ivec2 UV2;
 
 uniform sampler2D Sampler2;
 
@@ -25,8 +24,8 @@ out vec4 vertexColor;
 out vec4 lightmapColor;
 
 void main() {
-    vec4 WorldPosition = VeilCamera.ViewMat * vec4(Position, 1.0);
-    gl_Position = ProjMat * WorldPosition;
+    vec4 WorldPosition = (ParticleMat * vec4(Position * Scale, 1.0) + vec4(VeilCamera.CameraBobOffset, 0));
+    gl_Position = ProjMat * ModelViewMat * WorldPosition;
     vertexDistance = length(WorldPosition.xyz);
     vec2 uvs[4];
     uvs[0] = UV0Min,

--- a/wiki/Quasar.md
+++ b/wiki/Quasar.md
@@ -65,7 +65,7 @@ Syntax (note that all fields are required, none are optional):
   "random_initial_direction": true,
   // Currently unused. Use the init_random_rotation module.
   "random_initial_rotation": false,
-  // The inital direction of each particle, potentially modified by random_direction.
+  // The initial direction of each particle, potentially modified by random_direction.
   "initial_direction": [
     1.0,
     1.0,
@@ -141,7 +141,7 @@ We'll talk more about the individual types of modules later in this article.
 - **Folder Path (Render Modules): `modules/particle_data`**
 - **[Particle Data Codec](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/data/QuasarParticleData.java#L52)**
 
-Defines the properties attached to each particles. Includes any modules attached to the particle, how it is rendered, and various other properties. 
+Defines the properties attached to each particle. Includes any modules attached to the particle, how it is rendered, and various other properties. 
 
 Syntax:
 ```json5
@@ -150,24 +150,8 @@ Syntax:
   // The render style can be either "CUBE" or "BILLBOARD".
   // "BILLBOARD" is meant for particles with textures that always face the player, whereas "CUBE" displays colored, textureless cubes.
   "render_type": "CUBE",
-  // Init modules run once on a particle when it is spawned.
-  "init_modules": [
-    ...
-  ],
-  // Update modules run every tick while the particle is alive.
-  "update_modules": [
-    ...
-  ],
-  // Collision modules run once when the particle collides with something.
-  "collision_modules": [
-    ...
-  ],
-  // Force modules also run every tick while the particle is alive and apply different changes to velocity based on module.
-  "forces": [
-    ...
-  ],
-  // Render modules run every frame and can change how the particle appears.
-  "render_modules": [
+  // A list of modules that can be used to change the behavior of each particle.
+  "modules": [
     ...
   ],
   // Holds all information related to the sprite
@@ -216,8 +200,10 @@ When you don't know what fields an entry may have, search it up on [Veil's Githu
 
 ### Particle Editor
 
-Not currently finished! Please return at a later point for documentation and use a text editor
-of your choice for now.
+The particle editor is available in version 4.3.0 or later, and provides a GUI to assist creation and realtime inspecting and editing of particle emitters.
+To use the particle editor, ensure that Veil is >=4.3.0 and that ImGuiMC is installed. Press the editor key (F6 by default) to open the Veil menu; the particle editor will be under the "Resources" tab.
+
+The rest of this tutorial does not use the particle editor; it deals with raw JSON files using a text editor.
 
 ### Resource Browser
 
@@ -324,8 +310,8 @@ spawned and can be used to add different modules based on the module data. For e
 which, depending if any properties of the light vary over time, either adds a [`StaticLightModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/StaticLightModule.java) or a [`DynamicLightModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/render/DynamicLightModule.java) to
 the particle to save calculations.
 
-The module itself consists of a class that implements the [`ParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/ParticleModule.java) interface for the particle's lifecycle. Notably, a module that only implements `ParticleModule` will not be able to recieve other lifecycle events.
-Instead, implement one of [`InitParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/InitParticleModule.java), [`ForceParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/ForceParticleModule.java), [`UpdateParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/UpdateParticleModule.java), [`CollisionParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/CollisionParticleModule.java), [`RenderParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/RenderParticleModule.java) to recieve lifecycle events of the corresponding type.
+The module itself consists of a class that implements the [`ParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/ParticleModule.java) interface for the particle's lifecycle. Notably, a module that only implements `ParticleModule` will not be able to receive other lifecycle events.
+Instead, implement one of [`InitParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/InitParticleModule.java), [`ForceParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/ForceParticleModule.java), [`UpdateParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/UpdateParticleModule.java), [`CollisionParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/CollisionParticleModule.java), [`RenderParticleModule`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/emitters/module/RenderParticleModule.java) to receive lifecycle events of the corresponding type.
 
 Each Module Type has to be registered in the [`ParticleModuleTypeRegistry`](https://github.com/FoundryMC/Veil/blob/1.21/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java)
 so that Veil knows how to read it from the Module Data files.
@@ -455,7 +441,7 @@ This makes the particle appear as a cube rather than a billboarded sprite. It wi
 // modules/particle_data/burst_data.json
 {
   ...
-  "init_modules": [
+  "modules": [
     {
       "module": "light",
       "gradient": {
@@ -463,26 +449,18 @@ This makes the particle appear as a cube rather than a billboarded sprite. It wi
       },
       "brightness": "3 - q.agePercent * 3",
       "radius": 5
-    }
-  ],
-  "forces": [
+    },
     {
       "module": "drag",
       "strength": 0.9
-    }
-  ],
-  "update_modules": [
+    },
     {
       "module": "tick_size",
       "size": "0.1 - q.agePercent * 0.1"
-    }
-  ],
-  "collision_modules": [
+    },
     {
       "module": "die_on_collision"
-    }
-  ],
-  "render_modules": [
+    },
     {
       "module": "color",
       "gradient": {
@@ -490,7 +468,7 @@ This makes the particle appear as a cube rather than a billboarded sprite. It wi
           {
             "percent": 0,
             "color": "0xFF0000"
-          }
+          },
           {
             "percent": 1,
             "color": "0x0000FF"
@@ -500,7 +478,7 @@ This makes the particle appear as a cube rather than a billboarded sprite. It wi
           {
             "percent": 0,
             "alpha": 1
-          }
+          },
           {
             "percent": 1,
             "alpha": 0
@@ -512,7 +490,7 @@ This makes the particle appear as a cube rather than a billboarded sprite. It wi
   ]
 }
 ```
-Let's go through these modules one by one. For brevity, I've defined only one module for each section. For our init module, we have the `light` module. This adds a light of a given brightness and radius with a color. Both brightness and radius are Molang expressions, which allow us to change them over time. I've used a Molang expression for brightness, which makes the brightness fade from 3 to 0 over the span of the particle's lifetime. The rest is fixed: the radius will be 5, and the color will be pure white.
+Let's go through these modules one by one. For brevity, I've defined only one module of each type. For our init module (the first one in the list), we have the `light` module. This adds a light of a given brightness and radius with a color. Both brightness and radius are Molang expressions, which allow us to change them over time. I've used a Molang expression for brightness, which makes the brightness fade from 3 to 0 over the span of the particle's lifetime. The rest is fixed: the radius will be 5, and the color will be pure white.
 
 Next, our force module. The one we have is the `drag` module, which continually slows down the particle over time. For the `drag` module, a lower `strength` property means that the particle slows down quicker: think of it as though it is multiplying the particle's velocity by the `strength` property. Our update module changes the size of the particle based on the lifetime. In our Molang environment, `q.agePercent` resolves to a value between 0 and 1 that is representative of how long the particle is along its lifespan. Here we use this to interpolate the size from 0.1 to 0. The collision module has no properties and requires little explanation; it just immediately kills the particle on contact with the world.
 


### PR DESCRIPTION
Quasar's particles struggle with framerates in situations of higher particle counts. By using instancing for drawing the quads, significantly more particles can be drawn with a significantly lower performance cost.
Current version (4.3.0, no instancing used):

https://github.com/user-attachments/assets/7d075d5d-6d42-4ac0-94f5-25688a320b4c

PR version (Instancing used):

https://github.com/user-attachments/assets/2df0a937-9484-4100-b662-a9d2d6491d0c