### PR TITLE
Improve Quasar emitter rotation

### DIFF
--- a/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
@@ -7,11 +7,10 @@ import foundry.veil.api.util.CodecUtil;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.RegistryFileCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Vector3d;
-import org.joml.Vector3dc;
-import org.joml.Vector3fc;
+import org.joml.*;
 
 public record EmitterShapeSettings(EmitterShape shape,
                                    Vector3fc dimensions,
@@ -26,8 +25,8 @@ public record EmitterShapeSettings(EmitterShape shape,
     ).apply(instance, EmitterShapeSettings::new));
     public static final Codec<Holder<EmitterShapeSettings>> CODEC = RegistryFileCodec.create(QuasarParticles.EMITTER_SHAPE_SETTINGS, DIRECT_CODEC);
 
-    public Vector3d getPos(RandomSource randomSource, Vector3dc pos) {
-        return this.shape.getPoint(randomSource, this.dimensions, this.rotation, pos, this.fromSurface);
+    public Vector3d getPos(RandomSource randomSource, Vector3dc pos, Quaternionf rot) {
+        return this.shape.getPoint(randomSource, this.dimensions, this.rotation.add(rot.getEulerAnglesXYZ(new Vector3f()).mul(Mth.RAD_TO_DEG), new Vector3f()), pos, this.fromSurface);
     }
 
     public @Nullable ResourceLocation getRegistryId() {

--- a/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/EmitterShapeSettings.java
@@ -25,7 +25,14 @@ public record EmitterShapeSettings(EmitterShape shape,
     ).apply(instance, EmitterShapeSettings::new));
     public static final Codec<Holder<EmitterShapeSettings>> CODEC = RegistryFileCodec.create(QuasarParticles.EMITTER_SHAPE_SETTINGS, DIRECT_CODEC);
 
-    public Vector3d getPos(RandomSource randomSource, Vector3dc pos, Quaternionf rot) {
+    public Vector3d getPos(RandomSource randomSource, Vector3dc pos) {
+        return this.shape.getPoint(randomSource, this.dimensions, this.rotation, pos, this.fromSurface);
+    }
+
+    /**
+     * @since 4.5.0
+     */
+    public Vector3d getPos(RandomSource randomSource, Vector3dc pos, Quaternionfc rot) {
         return this.shape.getPoint(randomSource, this.dimensions, this.rotation.add(rot.getEulerAnglesXYZ(new Vector3f()).mul(Mth.RAD_TO_DEG), new Vector3f()), pos, this.fromSurface);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
@@ -11,6 +11,7 @@ import foundry.veil.api.quasar.data.module.force.*;
 import foundry.veil.api.quasar.data.module.init.*;
 import foundry.veil.api.quasar.data.module.render.ColorParticleModuleData;
 import foundry.veil.api.quasar.data.module.render.TrailParticleModuleData;
+import foundry.veil.api.quasar.data.module.update.TickRotationParticleModuleData;
 import foundry.veil.api.quasar.data.module.update.TickSizeParticleModuleData;
 import foundry.veil.api.quasar.data.module.update.TickSubEmitterModuleData;
 import foundry.veil.api.quasar.emitters.module.init.InitRandomRotationModuleData;
@@ -137,6 +138,7 @@ public class ParticleModuleTypeRegistry {
 
     // UPDATE
     public static final ModuleType<TickSizeParticleModuleData> TICK_SIZE = registerModule("size", TickSizeParticleModuleData.CODEC, () -> new TickSizeParticleModuleData(MolangExpression.of(1)));
+    public static final ModuleType<TickRotationParticleModuleData> TICK_ROTATION = registerModule("rotation", TickRotationParticleModuleData.CODEC, () -> new TickRotationParticleModuleData(MolangExpression.ZERO, MolangExpression.ZERO, MolangExpression.ZERO));
     public static final ModuleType<TickSubEmitterModuleData> TICK_SUB_EMITTER = registerModule("tick_sub_emitter", TickSubEmitterModuleData.CODEC, () -> new TickSubEmitterModuleData(ResourceLocation.withDefaultNamespace(""), 5));
     // UPDATE - COLLISION
     public static final ModuleType<DieOnCollisionModuleData> DIE_ON_COLLISION = registerModule("die_on_collision", DieOnCollisionModuleData.CODEC, DieOnCollisionModuleData::new);

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleModuleTypeRegistry.java
@@ -138,6 +138,9 @@ public class ParticleModuleTypeRegistry {
 
     // UPDATE
     public static final ModuleType<TickSizeParticleModuleData> TICK_SIZE = registerModule("size", TickSizeParticleModuleData.CODEC, () -> new TickSizeParticleModuleData(MolangExpression.of(1)));
+    /**
+     * @since 4.5.0
+     */
     public static final ModuleType<TickRotationParticleModuleData> TICK_ROTATION = registerModule("rotation", TickRotationParticleModuleData.CODEC, () -> new TickRotationParticleModuleData(MolangExpression.ZERO, MolangExpression.ZERO, MolangExpression.ZERO));
     public static final ModuleType<TickSubEmitterModuleData> TICK_SUB_EMITTER = registerModule("tick_sub_emitter", TickSubEmitterModuleData.CODEC, () -> new TickSubEmitterModuleData(ResourceLocation.withDefaultNamespace(""), 5));
     // UPDATE - COLLISION

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleSettings.java
@@ -7,6 +7,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.resources.RegistryFileCodec;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
@@ -45,6 +46,10 @@ public record ParticleSettings(float particleSpeed,
             Codec.BOOL.optionalFieldOf("random_lifetime", false).forGetter(ParticleSettings::randomLifetime)
     ).apply(instance, ParticleSettings::new));
     public static final Codec<Holder<ParticleSettings>> CODEC = RegistryFileCodec.create(QuasarParticles.PARTICLE_SETTINGS, DIRECT_CODEC);
+
+    @ApiStatus.Internal
+    public ParticleSettings {
+    }
 
     public float particleSpeed(RandomSource random) {
         return this.randomSpeed ? this.particleSpeed + random.nextFloat() * this.particleSpeedVariation : this.particleSpeed;

--- a/common/src/main/java/foundry/veil/api/quasar/data/ParticleSettings.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/ParticleSettings.java
@@ -12,28 +12,34 @@ import org.joml.Vector3f;
 import org.joml.Vector3fc;
 
 public record ParticleSettings(float particleSpeed,
+                               float particleSpeedVariation,
                                float particleSize,
                                float particleSizeVariation,
                                int particleLifetime,
                                float particleLifetimeVariation,
                                Vector3fc initialDirection,
                                boolean randomInitialDirection,
+                               Vector3fc initialDirectionVariation,
                                Vector3fc initialRotation,
                                boolean randomInitialRotation,
+                               Vector3fc initialRotationVariation,
                                boolean randomSpeed,
                                boolean randomSize,
                                boolean randomLifetime) {
 
     public static final Codec<ParticleSettings> DIRECT_CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.FLOAT.fieldOf("particle_speed").forGetter(ParticleSettings::particleSpeed),
+            Codec.FLOAT.optionalFieldOf("particle_speed_variation", 0f).forGetter(ParticleSettings::particleSpeedVariation),
             Codec.FLOAT.fieldOf("base_particle_size").forGetter(ParticleSettings::particleSize),
             Codec.FLOAT.optionalFieldOf("particle_size_variation", 0f).forGetter(ParticleSettings::particleSizeVariation),
             Codec.INT.fieldOf("particle_lifetime").forGetter(ParticleSettings::particleLifetime),
             Codec.FLOAT.optionalFieldOf("particle_lifetime_variation", 0f).forGetter(ParticleSettings::particleLifetimeVariation),
             CodecUtil.VECTOR3FC_CODEC.optionalFieldOf("initial_direction", new Vector3f(1)).forGetter(ParticleSettings::initialDirection),
             Codec.BOOL.optionalFieldOf("random_initial_direction", false).forGetter(ParticleSettings::randomInitialDirection),
+            CodecUtil.VECTOR3FC_CODEC.optionalFieldOf("initial_direction_variation", new Vector3f(0)).forGetter(ParticleSettings::initialDirectionVariation),
             CodecUtil.VECTOR3FC_CODEC.optionalFieldOf("initial_rotation", new Vector3f(0)).forGetter(ParticleSettings::initialRotation),
             Codec.BOOL.optionalFieldOf("random_initial_rotation", false).forGetter(ParticleSettings::randomInitialRotation),
+            CodecUtil.VECTOR3FC_CODEC.optionalFieldOf("initial_rotation_variation", new Vector3f(0)).forGetter(ParticleSettings::initialRotationVariation),
             Codec.BOOL.optionalFieldOf("random_speed", false).forGetter(ParticleSettings::randomSpeed),
             Codec.BOOL.optionalFieldOf("random_size", false).forGetter(ParticleSettings::randomSize),
             Codec.BOOL.optionalFieldOf("random_lifetime", false).forGetter(ParticleSettings::randomLifetime)
@@ -41,7 +47,7 @@ public record ParticleSettings(float particleSpeed,
     public static final Codec<Holder<ParticleSettings>> CODEC = RegistryFileCodec.create(QuasarParticles.PARTICLE_SETTINGS, DIRECT_CODEC);
 
     public float particleSpeed(RandomSource random) {
-        return this.randomSpeed ? this.particleSpeed + (random.nextFloat() * 0.5f - 0.5f) * this.particleSpeed : this.particleSpeed;
+        return this.randomSpeed ? this.particleSpeed + random.nextFloat() * this.particleSpeedVariation : this.particleSpeed;
     }
 
     public float particleSize(RandomSource random) {
@@ -53,14 +59,14 @@ public record ParticleSettings(float particleSpeed,
     }
 
     public Vector3fc initialDirection(RandomSource random) {
-        return this.randomInitialDirection ? this.initialDirection.mul(random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, new Vector3f()) : this.initialDirection;
+        return this.randomInitialDirection ? this.initialDirection.add(this.initialDirectionVariation.mul(random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, new Vector3f()), new Vector3f()) : this.initialDirection;
     }
 
     /**
      * @since 4.3.0
      */
     public Vector3fc initialRotation(RandomSource random) {
-        return this.randomInitialRotation ? this.initialRotation.mul(random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, new Vector3f()) : this.initialRotation;
+        return this.randomInitialRotation ? this.initialRotation.add(this.initialRotationVariation.mul(random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, random.nextFloat() * 2 - 1, new Vector3f()), new Vector3f()) : this.initialRotation;
     }
 
     public Vector3f particleDirection(RandomSource random) {

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitialVelocityModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/init/InitialVelocityModuleData.java
@@ -11,6 +11,7 @@ import foundry.veil.api.quasar.emitters.module.InitParticleModule;
 import foundry.veil.api.quasar.particle.ParticleModuleSet;
 import foundry.veil.api.util.CodecUtil;
 import imgui.ImGui;
+import org.joml.Quaterniond;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 
@@ -37,7 +38,7 @@ public final class InitialVelocityModuleData implements ParticleModuleData, Edit
     @Override
     public void addModules(ParticleModuleSet.Builder builder) {
         // TODO takesParentRotation
-        builder.addModule((InitParticleModule) particle -> particle.getVelocity().add(this.velocityDirection.normalize(this.strength, new Vector3d())));
+        builder.addModule((InitParticleModule) particle -> particle.getVelocity().add(this.velocityDirection.normalize(this.strength, new Vector3d()).rotate(particle.getEmitter().getRotation().get(new Quaterniond()))));
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickRotationParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickRotationParticleModuleData.java
@@ -1,0 +1,109 @@
+package foundry.veil.api.quasar.data.module.update;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import foundry.veil.api.client.editor.EditorAttributeProvider;
+import foundry.veil.api.molang.MolangExpressionCodec;
+import foundry.veil.api.molang.VeilMolang;
+import foundry.veil.api.quasar.data.ParticleModuleTypeRegistry;
+import foundry.veil.api.quasar.data.module.ModuleType;
+import foundry.veil.api.quasar.data.module.ParticleModuleData;
+import foundry.veil.api.quasar.emitters.module.UpdateParticleModule;
+import foundry.veil.api.quasar.particle.ParticleModuleSet;
+import gg.moonflower.molangcompiler.api.MolangExpression;
+import imgui.ImGui;
+import imgui.type.ImString;
+import net.minecraft.util.Mth;
+
+public final class TickRotationParticleModuleData implements ParticleModuleData, EditorAttributeProvider {
+    public static final MapCodec<TickRotationParticleModuleData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            MolangExpressionCodec.CODEC.fieldOf("x").forGetter(TickRotationParticleModuleData::rotationX),
+            MolangExpressionCodec.CODEC.fieldOf("y").forGetter(TickRotationParticleModuleData::rotationY),
+            MolangExpressionCodec.CODEC.fieldOf("z").forGetter(TickRotationParticleModuleData::rotationZ)
+    ).apply(instance, TickRotationParticleModuleData::new));
+    private MolangExpression rotationX, rotationY, rotationZ;
+
+    public TickRotationParticleModuleData(MolangExpression rotationX,
+                                          MolangExpression rotationY,
+                                          MolangExpression rotationZ) {
+        this.rotationX = rotationX;
+        this.rotationY = rotationY;
+        this.rotationZ = rotationZ;
+    }
+
+    @Override
+    public void renderImGuiAttributes() {
+        ImString rotationXInput = new ImString();
+        String rotationXString = this.rotationX.toString();
+        if (rotationXString.startsWith("return (")) {
+            rotationXInput.set(rotationXString.substring(8, rotationXString.length() - 1));
+        } else {
+            rotationXInput.set(rotationXString);
+        }
+
+        if (ImGui.inputText("x", rotationXInput)) {
+            try {
+                this.rotationX = VeilMolang.get().compile(rotationXInput.get());
+            } catch (Exception ignored) {
+            }
+        }
+
+        ImString rotationYInput = new ImString();
+        String rotationYString = this.rotationY.toString();
+        if (rotationYString.startsWith("return (")) {
+            rotationYInput.set(rotationYString.substring(8, rotationYString.length() - 1));
+        } else {
+            rotationYInput.set(rotationYString);
+        }
+
+        if (ImGui.inputText("y", rotationYInput)) {
+            try {
+                this.rotationY = VeilMolang.get().compile(rotationYInput.get());
+            } catch (Exception ignored) {
+            }
+        }
+
+        ImString rotationZInput = new ImString();
+        String rotationZString = this.rotationZ.toString();
+        if (rotationZString.startsWith("return (")) {
+            rotationZInput.set(rotationZString.substring(8, rotationZString.length() - 1));
+        } else {
+            rotationZInput.set(rotationZString);
+        }
+
+        if (ImGui.inputText("z", rotationZInput)) {
+            try {
+                this.rotationZ = VeilMolang.get().compile(rotationZInput.get());
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    @Override
+    public void addModules(ParticleModuleSet.Builder builder) {
+        builder.addModule((UpdateParticleModule) particle -> {
+            try {
+                particle.setRotation(particle.getEnvironment().resolve(this.rotationX) * Mth.DEG_TO_RAD, particle.getEnvironment().resolve(this.rotationY) * Mth.DEG_TO_RAD, particle.getEnvironment().resolve(this.rotationZ) * Mth.DEG_TO_RAD);
+            } catch (Exception ignored) {
+
+            }
+        });
+    }
+
+    @Override
+    public ModuleType<?> getType() {
+        return ParticleModuleTypeRegistry.TICK_ROTATION;
+    }
+
+    public MolangExpression rotationX() {
+        return rotationX;
+    }
+
+    public MolangExpression rotationY() {
+        return rotationY;
+    }
+
+    public MolangExpression rotationZ() {
+        return rotationZ;
+    }
+}

--- a/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickRotationParticleModuleData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/update/TickRotationParticleModuleData.java
@@ -15,6 +15,9 @@ import imgui.ImGui;
 import imgui.type.ImString;
 import net.minecraft.util.Mth;
 
+/**
+ * @since 4.5.0
+ */
 public final class TickRotationParticleModuleData implements ParticleModuleData, EditorAttributeProvider {
     public static final MapCodec<TickRotationParticleModuleData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             MolangExpressionCodec.CODEC.fieldOf("x").forGetter(TickRotationParticleModuleData::rotationX),

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/ConstantForceModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/ConstantForceModule.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.emitters.module.force;
 
 import foundry.veil.api.quasar.emitters.module.ForceParticleModule;
 import foundry.veil.api.quasar.particle.QuasarParticle;
+import org.joml.Quaterniond;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 
@@ -21,7 +22,8 @@ public class ConstantForceModule implements ForceParticleModule {
 
     @Override
     public void applyForce(QuasarParticle particle) {
-        particle.getVelocity().add(this.acceleration.x * this.strength, this.acceleration.y * this.strength, this.acceleration.z * this.strength);
+        Vector3d rotatedAcceleration = this.acceleration.rotate(particle.getEmitter().getRotation().get(new Quaterniond()), new Vector3d());
+        particle.getVelocity().add(rotatedAcceleration.x * this.strength, rotatedAcceleration.y * this.strength, rotatedAcceleration.z * this.strength);
     }
 
     @Override

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/SimplePositionedForce.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/SimplePositionedForce.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.emitters.module.force;
 
 import foundry.veil.api.quasar.emitters.module.ForceParticleModule;
 import foundry.veil.api.quasar.particle.QuasarParticle;
+import org.joml.Quaterniond;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 
@@ -23,7 +24,8 @@ public abstract class SimplePositionedForce implements ForceParticleModule, Posi
 
     protected Vector3d getDeltaPosition(QuasarParticle particle) {
         if (this.localPosition) {
-            return this.position.add(particle.getEmitter().getPosition(), this.tempPos).sub(particle.getPosition());
+            Vector3d rotatedPosition = position.rotate(particle.getEmitter().getRotation().get(new Quaterniond()), new Vector3d());
+            return rotatedPosition.add(particle.getEmitter().getPosition(), this.tempPos).sub(particle.getPosition());
         }
         return this.position.sub(particle.getPosition(), this.tempPos);
     }

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/VortexForceModule.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/module/force/VortexForceModule.java
@@ -2,6 +2,7 @@ package foundry.veil.api.quasar.emitters.module.force;
 
 import foundry.veil.api.quasar.data.module.force.VortexForceData;
 import foundry.veil.api.quasar.particle.QuasarParticle;
+import org.joml.Quaterniond;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 
@@ -38,9 +39,11 @@ public class VortexForceModule extends SimplePositionedForce {
         }
 
         // apply force to particle to move around the vortex center on the vortex axis, but do not modify outwards/inwards velocity
-        Vector3d particleToCenterOnAxis = diff.sub(this.vortexAxis.mul(diff.dot(this.vortexAxis), this.dot));
+        Vector3d rotatedAxis = this.vortexAxis.rotate(particle.getEmitter().getRotation().get(new Quaterniond()), new Vector3d()).normalize();
+
+        Vector3d particleToCenterOnAxis = diff.sub(rotatedAxis.mul(diff.dot(rotatedAxis), this.dot));
         particleToCenterOnAxis.normalize();
-        particleToCenterOnAxis.cross(this.vortexAxis).mul(this.strength);
+        particleToCenterOnAxis.cross(rotatedAxis).mul(this.strength);
         particle.getVelocity().add(particleToCenterOnAxis);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Cube.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Cube.java
@@ -12,7 +12,7 @@ import java.lang.Math;
 public class Cube implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double x = randomSource.nextDouble() * 2 - 1;
         double y = randomSource.nextDouble() * 2 - 1;
         double z = randomSource.nextDouble() * 2 - 1;
@@ -28,7 +28,11 @@ public class Cube implements EmitterShape {
         }
         Vector3d normal = new Vector3d(x, y, z);
         Vector3d pos = normal.mul(dimensions).mul(0.5);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        new Matrix4d().rotate(new Quaternionf().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z()))).transformPosition(pos);
+        //pos.rotateAxis(Math.toRadians(shapeRotation.x()), 1, 0, 0);
+        //pos.rotateAxis(Math.toRadians(shapeRotation.y()), 0, 1, 0);
+        //pos.rotateAxis(Math.toRadians(shapeRotation.z()), 0, 0, 1);
+        //pos.rotate(new Quaterniond().rotateLocalX((float) Math.toRadians(shapeRotation.x())).rotateLocalY( (float) Math.toRadians(shapeRotation.y())).rotateLocalZ( (float) Math.toRadians(shapeRotation.z())));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Cylinder.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Cylinder.java
@@ -10,7 +10,7 @@ import java.lang.Math;
 public class Cylinder implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double theta = randomSource.nextDouble() * 2 * Math.PI;
         double x = Math.cos(theta);
         double y = randomSource.nextDouble() * 2 - 1;
@@ -27,7 +27,7 @@ public class Cylinder implements EmitterShape {
             );
         }
         Vector3d pos = normal.mul(dim);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z())));
         pos.mul(0.5);
         return pos.add(position);
     }

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Disc.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Disc.java
@@ -10,7 +10,7 @@ import java.lang.Math;
 public class Disc implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double x = randomSource.nextDouble() * 2 - 1;
         double y = 0;
         double z = randomSource.nextDouble() * 2 - 1;
@@ -26,7 +26,7 @@ public class Disc implements EmitterShape {
             );
         }
         Vector3d pos = normal.mul(dim).mul(0.5);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z())));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/EmitterShape.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/EmitterShape.java
@@ -12,7 +12,7 @@ import org.joml.Vector3fc;
 
 public interface EmitterShape {
 
-    Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface);
+    Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface);
 
     void renderShape(PoseStack stack, VertexConsumer consumer, Vector3fc dimensions, Vector3fc rotation);
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Hemisphere.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Hemisphere.java
@@ -12,7 +12,7 @@ import static foundry.veil.api.quasar.emitters.shape.Sphere.parametricSphere;
 public class Hemisphere implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double theta = randomSource.nextDouble() * 2 * Math.PI;
         double phi = randomSource.nextDouble() * Math.PI / 2;
         double x = Math.cos(theta) * Math.sin(phi);
@@ -30,7 +30,7 @@ public class Hemisphere implements EmitterShape {
             );
         }
         Vector3d pos = normal.mul(dim).mul(0.5);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z())));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Plane.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Plane.java
@@ -12,7 +12,7 @@ import java.lang.Math;
 public class Plane implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double x = randomSource.nextDouble() - 0.5;
         double y = 0;
         double z = randomSource.nextDouble() - 0.5;
@@ -25,7 +25,7 @@ public class Plane implements EmitterShape {
         }
         Vector3d normal = new Vector3d(x, y, z);
         Vector3d pos = normal.mul(dimensions);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z())));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Point.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Point.java
@@ -12,7 +12,7 @@ import org.joml.Vector3fc;
 public class Point implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         return new Vector3d(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Sphere.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Sphere.java
@@ -11,7 +11,7 @@ import java.lang.Math;
 public class Sphere implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double x = randomSource.nextDouble() - 0.5;
         double y = randomSource.nextDouble() - 0.5;
         double z = randomSource.nextDouble() - 0.5;
@@ -27,7 +27,7 @@ public class Sphere implements EmitterShape {
             );
         }
         Vector3d pos = normal.mul(dim).mul(0.5);
-        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(rotation.x()), (float) Math.toRadians(rotation.y()), (float) Math.toRadians(rotation.z())));
+        pos = pos.rotate(new Quaterniond().rotationXYZ((float) Math.toRadians(shapeRotation.x()), (float) Math.toRadians(shapeRotation.y()), (float) Math.toRadians(shapeRotation.z())));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Torus.java
+++ b/common/src/main/java/foundry/veil/api/quasar/emitters/shape/Torus.java
@@ -3,15 +3,14 @@ package foundry.veil.api.quasar.emitters.shape;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.util.RandomSource;
-import org.joml.Vector3d;
-import org.joml.Vector3dc;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
+
+import java.lang.Math;
 
 public class Torus implements EmitterShape {
 
     @Override
-    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc rotation, Vector3dc position, boolean fromSurface) {
+    public Vector3d getPoint(RandomSource randomSource, Vector3fc dimensions, Vector3fc shapeRotation, Vector3dc position, boolean fromSurface) {
         double theta = randomSource.nextDouble() * 2 * Math.PI;
         double phi = randomSource.nextDouble() * 2 * Math.PI;
         double x = Math.cos(theta) * (1 + 0.5 * Math.cos(phi));
@@ -29,7 +28,7 @@ public class Torus implements EmitterShape {
             );
         }
         Vector3d pos = normal.mul(dim);
-        pos = pos.rotateX((float) Math.toRadians(rotation.x())).rotateY((float) Math.toRadians(rotation.y())).rotateZ((float) Math.toRadians(rotation.z()));
+        pos = pos.rotateX((float) Math.toRadians(shapeRotation.x())).rotateY((float) Math.toRadians(shapeRotation.y())).rotateZ((float) Math.toRadians(shapeRotation.z()));
         return pos.add(position);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -116,7 +116,7 @@ public class ParticleEmitter {
 
         for (int i = 0; i < count; i++) {
             Vector3dc particlePos = this.emitterShapeSettings.get(i % this.emitterShapeSettings.size()).getPos(this.randomSource, this.getPosition(), this.getRotation());
-            Vector3fc particleDirection = this.particleSettings.particleDirection(this.randomSource);
+            Vector3fc particleDirection = this.particleSettings.particleDirection(this.randomSource).rotate(this.getRotation());
             Vector3fc particleRotation = this.particleSettings.initialRotation(this.randomSource).mul(Mth.DEG_TO_RAD, new Vector3f()).add(this.getRotation().getEulerAnglesXYZ(new Vector3f()));
 
             // TODO

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -20,11 +20,9 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
-import org.joml.Vector3d;
-import org.joml.Vector3dc;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
 
+import java.lang.Math;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
@@ -53,6 +51,7 @@ public class ParticleEmitter {
     private final List<ParticleModuleData> modulesView;
     private final RandomSource randomSource;
     private final Vector3d position;
+    private final Quaternionf rotation;
     private final Vector3d offset;
     private final List<QuasarParticle> particles;
 
@@ -80,6 +79,7 @@ public class ParticleEmitter {
         this.modulesView = Collections.unmodifiableList(this.modules);
         this.randomSource = RandomSource.create();
         this.position = new Vector3d();
+        this.rotation = new Quaternionf();
         this.offset = new Vector3d();
         this.particles = new LinkedList<>();
 
@@ -115,9 +115,9 @@ public class ParticleEmitter {
         this.particleManager.reserve(count);
 
         for (int i = 0; i < count; i++) {
-            Vector3dc particlePos = this.emitterShapeSettings.get(i % this.emitterShapeSettings.size()).getPos(this.randomSource, this.position);
+            Vector3dc particlePos = this.emitterShapeSettings.get(i % this.emitterShapeSettings.size()).getPos(this.randomSource, this.getPosition(), this.getRotation());
             Vector3fc particleDirection = this.particleSettings.particleDirection(this.randomSource);
-            Vector3fc particleRotation = this.particleSettings.initialRotation(this.randomSource).mul(Mth.DEG_TO_RAD, new Vector3f());
+            Vector3fc particleRotation = this.particleSettings.initialRotation(this.randomSource).mul(Mth.DEG_TO_RAD, new Vector3f()).add(this.getRotation().getEulerAnglesXYZ(new Vector3f()));
 
             // TODO
 //        this.getParticleData().getInitModules().stream().filter(force -> force instanceof InitialVelocityForce).forEach(f -> {
@@ -346,6 +346,13 @@ public class ParticleEmitter {
         return this.position;
     }
 
+    /**
+     * Rotation of the emitter
+     */
+    public Quaternionf getRotation() {
+        return this.rotation;
+    }
+
     public ParticleEmitterData getData() {
         return this.emitterData;
     }
@@ -429,6 +436,26 @@ public class ParticleEmitter {
         } else {
             this.position.set(this.offset);
         }
+    }
+
+    /**
+     * Sets the rotation of the particle emitter.
+     *
+     * @param x The rotation about the X axis, in radians.
+     * @param y The rotation about the Y axis, in radians.
+     * @param z The rotation about the Z axis, in radians.
+     */
+    public void setRotation(float x, float y, float z) {
+        this.rotation.identity().rotateLocalX(x).rotateLocalY(y).rotateLocalZ(z);
+    }
+
+    /**
+     * Sets the rotation of the particle emitter.
+     *
+     * @param rotation The rotation of the emitter.
+     */
+    public void setRotation(Quaternionf rotation) {
+        this.rotation.set(rotation);
     }
 
     public void setMaxLifetime(int maxLifetime) {

--- a/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/ParticleEmitter.java
@@ -348,6 +348,8 @@ public class ParticleEmitter {
 
     /**
      * Rotation of the emitter
+     *
+     * @since 4.5.0
      */
     public Quaternionf getRotation() {
         return this.rotation;
@@ -444,6 +446,7 @@ public class ParticleEmitter {
      * @param x The rotation about the X axis, in radians.
      * @param y The rotation about the Y axis, in radians.
      * @param z The rotation about the Z axis, in radians.
+     * @since 4.5.0
      */
     public void setRotation(float x, float y, float z) {
         this.rotation.identity().rotateLocalX(x).rotateLocalY(y).rotateLocalZ(z);
@@ -453,8 +456,9 @@ public class ParticleEmitter {
      * Sets the rotation of the particle emitter.
      *
      * @param rotation The rotation of the emitter.
+     * @since 4.5.0
      */
-    public void setRotation(Quaternionf rotation) {
+    public void setRotation(Quaternionfc rotation) {
         this.rotation.set(rotation);
     }
 

--- a/common/src/main/java/foundry/veil/api/quasar/particle/QuasarParticle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/QuasarParticle.java
@@ -268,6 +268,10 @@ public class QuasarParticle {
         return this.rotation;
     }
 
+    public void setRotation(float x, float y, float z) {
+        this.rotation.set(x, y, z);
+    }
+
     public float getRadius() {
         return this.radius;
     }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/QuasarParticle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/QuasarParticle.java
@@ -268,6 +268,9 @@ public class QuasarParticle {
         return this.rotation;
     }
 
+    /**
+     * @since 4.5.0
+     */
     public void setRotation(float x, float y, float z) {
         this.rotation.set(x, y, z);
     }

--- a/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
+++ b/common/src/main/java/foundry/veil/api/quasar/particle/RenderStyle.java
@@ -271,7 +271,7 @@ public abstract class RenderStyle implements NativeResource {
 
             Matrix4f transformationMatrix = new Matrix4f()
                     .translate(renderOffset.x, renderOffset.y, renderOffset.z)
-                    .rotate(new Quaternionf().rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()));
+                    .rotate(new Quaternionf().rotationXYZ(rotation.x(), rotation.y(), rotation.z()));
             transformationMatrix.get(buffer.position(), buffer);
 
             buffer.position(buffer.position() + Float.BYTES * 16);
@@ -360,7 +360,7 @@ public abstract class RenderStyle implements NativeResource {
 
             Matrix4f transformationMatrix = new Matrix4f()
                     .translate(renderOffset.x, renderOffset.y, renderOffset.z)
-                    .rotate(faceCameraRotation.rotateLocalX(rotation.x()).rotateLocalY(rotation.y()).rotateLocalZ(rotation.z()));
+                    .rotate(faceCameraRotation.rotateXYZ(rotation.x(), rotation.y(), rotation.z()));
             transformationMatrix.get(buffer.position(), buffer);
 
             buffer.position(buffer.position() + Float.BYTES * 16);

--- a/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
+++ b/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
@@ -45,6 +45,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix4f;
+import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
 
@@ -228,10 +229,17 @@ public class ParticleEditorInspector extends SingleWindowInspector {
 
         ImGui.text("Particles: " + emitter.getParticleCount());
 
+        Vector3f emitterRotationEuler = emitter.getRotationVector().mul(Mth.RAD_TO_DEG, new Vector3f());
+
         float[] editPos = new float[]{(float) emitter.getPosition().x(), (float) emitter.getPosition().y(), (float) emitter.getPosition().z()};
+        float[] editRot = new float[]{emitterRotationEuler.x(), emitterRotationEuler.y(), emitterRotationEuler.z()};
 
         if (ImGui.dragFloat3("position", editPos, 0.02F)) {
             emitter.setPosition(editPos[0], editPos[1], editPos[2]);
+        }
+
+        if (ImGui.dragFloat3("rotation", editRot, 0.1F)) {
+            emitter.setRotation(editRot[0] * Mth.DEG_TO_RAD, editRot[1] * Mth.DEG_TO_RAD, editRot[2] * Mth.DEG_TO_RAD);
         }
 
         // General (emitters)
@@ -632,6 +640,9 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         public boolean renderEmitterShape = false;
         public boolean renderDirection;
 
+        // In order to facilitate an easier use of rotation, we store this as a Vector3f instead of a Quaternion
+        private final Vector3f rotation = new Vector3f();
+
         private MutableParticleEmitter(ParticleSystemManager particleManager, ClientLevel level, ParticleEmitterData data) {
             super(particleManager, level, data);
             this.particleData = new QuasarParticleData(this.particleData.shouldCollide(), this.particleData.faceVelocity(), this.particleData.velocityStretchFactor(), this.particleData.modules(), this.particleData.spriteData(), this.particleData.additive(), this.particleData.renderStyle());
@@ -656,7 +667,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                 for (EmitterShapeSettings shapeSettings : this.getEmitterShapeSettings()) {
                     matrixStack.matrixPush();
                     matrixStack.translate(this.getPosition());
-                    shapeSettings.shape().renderShape(matrixStack.toPoseStack(), debugBuilder, shapeSettings.dimensions(), shapeSettings.rotation());
+                    shapeSettings.shape().renderShape(matrixStack.toPoseStack(), debugBuilder, shapeSettings.dimensions(), shapeSettings.rotation().add(this.rotation.mul(Mth.RAD_TO_DEG, new Vector3f()), new Vector3f()));
                     matrixStack.matrixPop();
                 }
                 matrixStack.matrixPop();
@@ -687,6 +698,25 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                 this.reset();
                 this.spawnTask = this.particleManager.getScheduler().scheduleAtFixedRate(this::spawn, 1, this.getRate()).toCompletableFuture();
             }
+        }
+
+        public Vector3f getRotationVector() {
+            return this.rotation;
+        }
+
+        @Override
+        public Quaternionf getRotation() {
+            return new Quaternionf().rotationXYZ(this.rotation.x, this.rotation.y, this.rotation.z);
+        }
+
+        @Override
+        public void setRotation(Quaternionf rotation) {
+            this.rotation.set(rotation.getEulerAnglesXYZ(new Vector3f()));
+        }
+
+        @Override
+        public void setRotation(float x, float y, float z) {
+            this.rotation.set(x, y, z);
         }
 
         public void setRate(int rate) {

--- a/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
+++ b/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
@@ -132,7 +132,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                     Integer.MAX_VALUE,
                     new EmitterSettings(
                             List.of(Holder.direct(new EmitterShapeSettings(EmitterShapeRegistry.POINT.get(), new Vector3f(1), new Vector3f(0), true))),
-                            Holder.direct(new ParticleSettings(0.1f, 0.1f, 0, 60, 0, new Vector3f(1), true, new Vector3f(0), false, false, false, false)),
+                            Holder.direct(new ParticleSettings(0.1f, 0, 0.1f, 0, 60, 0, new Vector3f(0), true, new Vector3f(1), new Vector3f(0), false, new Vector3f(0), false, false, false)),
                             false
                     ),
                     Holder.direct(new QuasarParticleData(true, false, 0.0f, List.of(), null, false, RenderStyleRegistry.CUBE.get()))
@@ -292,7 +292,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
 
         float width = ImGui.getContentRegionAvailX() * 0.333f;
         ImGui.setNextItemWidth(width);
-        if (ImGui.dragScalar("rate", editRate, 0.02F)) {
+        if (ImGui.dragScalar("rate", editRate, 0.02F, 1, Integer.MAX_VALUE)) {
             emitter.setRate(editRate[0]);
         }
         ImGui.sameLine();
@@ -407,6 +407,13 @@ public class ParticleEditorInspector extends SingleWindowInspector {
             emitter.setParticleDirection(editDirection[0], editDirection[1], editDirection[2]);
         }
 
+        if (settings.randomInitialDirection()) {
+            float[] editDirectionVariation = new float[]{settings.initialDirectionVariation().x(), settings.initialDirectionVariation().y(), settings.initialDirectionVariation().z()};
+            if (ImGui.dragFloat3("initial_direction_variation", editDirectionVariation, 0.01F)) {
+                emitter.setParticleDirectionVariation(editDirectionVariation[0], editDirectionVariation[1], editDirectionVariation[2]);
+            }
+        }
+
         if (ImGui.checkbox("random_initial_rotation", settings.randomInitialRotation())) {
             emitter.toggleRandomRotation();
         }
@@ -416,14 +423,29 @@ public class ParticleEditorInspector extends SingleWindowInspector {
             emitter.setParticleRotation(editRotation[0], editRotation[1], editRotation[2]);
         }
 
+        if (settings.randomInitialRotation()) {
+            float[] editRotationVariation = new float[]{settings.initialRotationVariation().x(), settings.initialRotationVariation().y(), settings.initialRotationVariation().z()};
+            if (ImGui.dragFloat3("initial_rotation_variation", editRotationVariation, 0.025F)) {
+                emitter.setParticleRotationVariation(editRotationVariation[0], editRotationVariation[1], editRotationVariation[2]);
+            }
+        }
+
         if (ImGui.checkbox("random_speed", settings.randomSpeed())) {
             emitter.toggleRandomSpeed();
         }
 
-        float[] editSpeed = new float[]{settings.particleSpeed()};
+        if (settings.randomSpeed()) {
+            float[] editSpeed = new float[]{settings.particleSpeed(), settings.particleSpeed() + settings.particleSpeedVariation()};
 
-        if (ImGui.dragScalar("particle_speed", editSpeed, 0.01F)) {
-            emitter.setParticleSpeed(editSpeed[0]);
+            if (ImGui.dragFloat2("particle_speed", editSpeed, 0.01F, 0, editSpeed[1] + 0.01F)) {
+                emitter.setParticleSpeed(editSpeed[0], editSpeed[1]);
+            }
+        } else {
+            float[] editSpeed = new float[]{settings.particleSpeed()};
+
+            if (ImGui.dragScalar("particle_speed", editSpeed, 0.01F)) {
+                emitter.setParticleSpeed(editSpeed[0], 0);
+            }
         }
 
         if (ImGui.checkbox("random_size", settings.randomSize())) {
@@ -433,7 +455,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         if (settings.randomSize()) {
             float[] editParticleSize = new float[]{settings.particleSize(), settings.particleSize() + settings.particleSizeVariation()};
 
-            if (ImGui.dragFloat2("particle_size", editParticleSize, 0.01F, Math.max(editParticleSize[0], 0.001f), editParticleSize[1])) {
+            if (ImGui.dragFloat2("particle_size", editParticleSize, 0.01F, Math.max(editParticleSize[0] - 0.01F, 0.001f), editParticleSize[1] + 0.01F)) {
                 emitter.setParticleSize(editParticleSize[0], editParticleSize[1]);
             }
         } else {
@@ -450,7 +472,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         if (settings.randomLifetime()) {
             int[] editParticleLifetime = new int[]{settings.particleLifetime(), settings.particleLifetime() + (int) settings.particleLifetimeVariation()};
 
-            if (ImGui.dragInt2("particle_lifetime", editParticleLifetime, 0.03F, Math.max(editParticleLifetime[0], 0))) {
+            if (ImGui.dragInt2("particle_lifetime", editParticleLifetime, 0.03F, editParticleLifetime[0] - 1, editParticleLifetime[1] + 1)) {
                 emitter.setParticleLifetime(editParticleLifetime[0], editParticleLifetime[1]);
             }
         } else {
@@ -548,6 +570,10 @@ public class ParticleEditorInspector extends SingleWindowInspector {
             String name = String.valueOf(ParticleModuleTypeRegistry.REGISTRY.getKey(module.getType()));
             if (ImGui.collapsingHeader(name)) {
                 ImGui.indent();
+                ModuleType.DeprecationStatus status = module.getType().deprecationStatus();
+                if (status != null) {
+                    ImGui.textColored(0xFF00FFFF, "DEPRECATED MODULE: %s will be removed in %s (%s)".formatted(name, status.removeVersion(), status.reason()));
+                }
                 if (module instanceof EditorAttributeProvider attributeProvider) {
                     attributeProvider.renderImGuiAttributes();
                 }
@@ -558,10 +584,6 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                     continue;
                 }
                 ImGui.unindent();
-            }
-            ModuleType.DeprecationStatus status = module.getType().deprecationStatus();
-            if (status != null && ImGui.isItemHovered()) {
-                ImGui.setTooltip("%s will be removed in %s".formatted(name, status.removeVersion()));
             }
             ImGui.popID();
             id++;
@@ -715,11 +737,22 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                 matrixStack.translate(this.getPosition());
                 matrixStack.rotate(this.getRotation());
 
-                Matrix4f matrix4f = matrixStack.position();
+                Matrix4f pose = matrixStack.position();
 
-                debugBuilder.addVertex(matrix4f, 0, 0, 0).setColor(1, 1f, 1f, 1).setNormal(0, 1, 0);
                 Vector3f direction = this.getParticleSettings().initialDirection().normalize(new Vector3f()).mul(this.getParticleSettings().particleSpeed() * 10);
-                debugBuilder.addVertex(matrix4f, direction.x, direction.y, direction.z).setColor(1f, 0.15f, 0.15f, 1f).setNormal(0, 1, 0);
+                debugBuilder.addVertex(pose, 0, 0, 0).setColor(1, 1f, 1f, 1).setNormal(matrixStack.pose(), direction.x, direction.y, direction.z);
+                debugBuilder.addVertex(pose, direction.x, direction.y, direction.z).setColor(1f, 0.15f, 0.15f, 1f).setNormal(matrixStack.pose(), direction.x, direction.y, direction.z);
+
+                if (this.getParticleSettings().randomInitialDirection()) {
+                    Vector3f minDirection = this.getParticleSettings().initialDirection().add(this.getParticleSettings().initialDirectionVariation().mul(-1, new Vector3f()), new Vector3f()).mul(this.getParticleSettings().particleSpeed() * 10);
+                    Vector3f maxDirection = this.getParticleSettings().initialDirection().add(this.getParticleSettings().initialDirectionVariation(), new Vector3f()).mul(this.getParticleSettings().particleSpeed() * 10);
+                    debugBuilder.addVertex(pose, 0, 0, 0).setColor(1, 1f, 1f, 1).setNormal(matrixStack.pose(), minDirection.x, minDirection.y, minDirection.z);
+                    debugBuilder.addVertex(pose, minDirection.x, minDirection.y, minDirection.z).setColor(0.15f, 0.15f, 1f, 1f).setNormal(matrixStack.pose(), minDirection.x, minDirection.y, minDirection.z);
+
+                    debugBuilder.addVertex(pose, 0, 0, 0).setColor(1, 1f, 1f, 1).setNormal(matrixStack.pose(), maxDirection.x, maxDirection.y, maxDirection.z);
+                    debugBuilder.addVertex(pose, maxDirection.x, maxDirection.y, maxDirection.z).setColor(0.15f, 0.15f, 1f, 1f).setNormal(matrixStack.pose(), maxDirection.x, maxDirection.y, maxDirection.z);
+                }
+
                 matrixStack.matrixPop();
                 matrixStack.matrixPop();
             }
@@ -795,9 +828,11 @@ public class ParticleEditorInspector extends SingleWindowInspector {
             this.updateShapeSettings(index, oldShape.shape(), new Vector3f(1, 1, 1), new Vector3f(0, 0, 0), oldShape.fromSurface());
         }
 
-        public void setParticleSpeed(float speed) {
+        public void setParticleSpeed(float min, float max) {
+            max = Math.max(min, max);
             this.setParticleSettings(new ParticleSettingsBuilder(this.getParticleSettings())
-                    .setParticleSpeed(speed)
+                    .setParticleSpeed(min)
+                    .setParticleSpeedVariation(max - min)
                     .build());
         }
 
@@ -853,9 +888,21 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                     .build());
         }
 
+        public void setParticleDirectionVariation(float x, float y, float z) {
+            this.setParticleSettings(new ParticleSettingsBuilder(this.getParticleSettings())
+                    .setInitialDirectionVariation(new Vector3f(x, y, z))
+                    .build());
+        }
+
         public void setParticleRotation(float x, float y, float z) {
             this.setParticleSettings(new ParticleSettingsBuilder(this.getParticleSettings())
                     .setInitialRotation(new Vector3f(x, y, z))
+                    .build());
+        }
+
+        public void setParticleRotationVariation(float x, float y, float z) {
+            this.setParticleSettings(new ParticleSettingsBuilder(this.getParticleSettings())
+                    .setInitialRotationVariation(new Vector3f(x, y, z))
                     .build());
         }
 
@@ -866,28 +913,34 @@ public class ParticleEditorInspector extends SingleWindowInspector {
 
         private static class ParticleSettingsBuilder {
             private float particleSpeed;
+            private float particleSpeedVariation;
             private float particleSize;
             private float particleSizeVariation;
             private int particleLifetime;
             private float particleLifetimeVariation;
             private Vector3fc initialDirection;
             private boolean randomInitialDirection;
+            private Vector3fc initialDirectionVariation;
             private Vector3fc initialRotation;
             private boolean randomInitialRotation;
+            private Vector3fc initialRotationVariation;
             private boolean randomSpeed;
             private boolean randomSize;
             private boolean randomLifetime;
 
             public ParticleSettingsBuilder(ParticleSettings from) {
                 this.particleSpeed = from.particleSpeed();
+                this.particleSpeedVariation = from.particleSpeedVariation();
                 this.particleSize = from.particleSize();
                 this.particleSizeVariation = from.particleSizeVariation();
                 this.particleLifetime = from.particleLifetime();
                 this.particleLifetimeVariation = from.particleLifetimeVariation();
                 this.initialDirection = from.initialDirection();
                 this.randomInitialDirection = from.randomInitialDirection();
+                this.initialDirectionVariation = from.initialDirectionVariation();
                 this.initialRotation = from.initialRotation();
                 this.randomInitialRotation = from.randomInitialRotation();
+                this.initialRotationVariation = from.initialRotationVariation();
                 this.randomSpeed = from.randomSpeed();
                 this.randomSize = from.randomSize();
                 this.randomLifetime = from.randomLifetime();
@@ -953,8 +1006,23 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                 return this;
             }
 
+            public ParticleSettingsBuilder setInitialDirectionVariation(Vector3fc initialDirectionVariation) {
+                this.initialDirectionVariation = initialDirectionVariation;
+                return this;
+            }
+
+            public ParticleSettingsBuilder setInitialRotationVariation(Vector3fc initialRotationVariation) {
+                this.initialRotationVariation = initialRotationVariation;
+                return this;
+            }
+
+            public ParticleSettingsBuilder setParticleSpeedVariation(float particleSpeedVariation) {
+                this.particleSpeedVariation = particleSpeedVariation;
+                return this;
+            }
+
             public ParticleSettings build() {
-                return new ParticleSettings(this.particleSpeed, this.particleSize, this.particleSizeVariation, this.particleLifetime, this.particleLifetimeVariation, this.initialDirection, this.randomInitialDirection, this.initialRotation, this.randomInitialRotation, this.randomSpeed, this.randomSize, this.randomLifetime);
+                return new ParticleSettings(this.particleSpeed, this.particleSpeedVariation, this.particleSize, this.particleSizeVariation, this.particleLifetime, this.particleLifetimeVariation, this.initialDirection, this.randomInitialDirection, this.initialDirectionVariation, this.initialRotation, this.randomInitialRotation, this.initialRotationVariation, this.randomSpeed, this.randomSize, this.randomLifetime);
             }
         }
     }

--- a/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
+++ b/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
@@ -41,17 +41,17 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
-import org.joml.Matrix4f;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.Math;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
@@ -235,11 +235,46 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         float[] editRot = new float[]{emitterRotationEuler.x(), emitterRotationEuler.y(), emitterRotationEuler.z()};
 
         if (ImGui.dragFloat3("position", editPos, 0.02F)) {
-            emitter.setPosition(editPos[0], editPos[1], editPos[2]);
+            Entity attached = emitter.getAttachedEntity();
+            Vector3f entityPos = attached == null ? new Vector3f() : new Vector3f((float) attached.getX(), (float) attached.getY(), (float) attached.getZ());
+            emitter.setAttachedEntity(null);
+            emitter.setPosition(editPos[0] - entityPos.x, editPos[1] - entityPos.y, editPos[2] - entityPos.z);
+            emitter.setAttachedEntity(attached);
         }
 
         if (ImGui.dragFloat3("rotation", editRot, 0.1F)) {
             emitter.setRotation(editRot[0] * Mth.DEG_TO_RAD, editRot[1] * Mth.DEG_TO_RAD, editRot[2] * Mth.DEG_TO_RAD);
+        }
+
+        if (Minecraft.getInstance().crosshairPickEntity != null) {
+            if (ImGui.button("Attach to entity")) {
+                emitter.setAttachedEntity(Minecraft.getInstance().crosshairPickEntity);
+                emitter.setPosition(Vec3.ZERO);
+            }
+        } else if (Minecraft.getInstance().hitResult != null && Minecraft.getInstance().hitResult.getType() == HitResult.Type.BLOCK) {
+            if (ImGui.button("Place on block")) {
+                emitter.setAttachedEntity(null);
+                BlockHitResult blockHitResult = ((BlockHitResult) Minecraft.getInstance().hitResult);
+                emitter.setPosition(blockHitResult.getBlockPos().getCenter().add(new Vec3(blockHitResult.getDirection().step().mul(0.5f))));
+                emitter.setRotation(blockHitResult.getDirection().getRotation());
+            }
+        } else {
+            if (ImGui.button("Move to view")) {
+                emitter.setAttachedEntity(null);
+                Camera camera = Minecraft.getInstance().gameRenderer.getMainCamera();
+                emitter.setPosition(camera.getPosition().add(new Vec3(camera.getLookVector()).scale(4)));
+            }
+        }
+
+        if (emitter.getAttachedEntity() != null) {
+            ImGui.sameLine();
+            if (ImGui.button("Remove from entity")) {
+                Entity attached = emitter.getAttachedEntity();
+                Vector3d targetPosition = new Vector3d(attached.getX(), attached.getY(), attached.getZ());
+                Vector3d offset = emitter.getPosition().sub(targetPosition, new Vector3d());
+                emitter.setAttachedEntity(null);
+                emitter.setPosition(targetPosition.add(offset));
+            }
         }
 
         // General (emitters)
@@ -678,6 +713,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
                 matrixStack.translate(-camera.getPosition().x, -camera.getPosition().y, -camera.getPosition().z);
                 matrixStack.matrixPush();
                 matrixStack.translate(this.getPosition());
+                matrixStack.rotate(this.getRotation());
 
                 Matrix4f matrix4f = matrixStack.position();
 
@@ -710,8 +746,8 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         }
 
         @Override
-        public void setRotation(Quaternionf rotation) {
-            this.rotation.set(rotation.getEulerAnglesXYZ(new Vector3f()));
+        public void setRotation(Quaternionf newRot) {
+            newRot.getEulerAnglesXYZ(this.rotation);
         }
 
         @Override

--- a/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
+++ b/common/src/main/java/foundry/veil/impl/client/editor/ParticleEditorInspector.java
@@ -779,7 +779,7 @@ public class ParticleEditorInspector extends SingleWindowInspector {
         }
 
         @Override
-        public void setRotation(Quaternionf newRot) {
+        public void setRotation(Quaternionfc newRot) {
             newRot.getEulerAnglesXYZ(this.rotation);
         }
 


### PR DESCRIPTION
This PR implements a `rotation` property for Quasar's particle emitters, allowing them to be seamlessly rotated. This functionality is also implemented in any relevant force modules. Additionally, this PR provides a rotation module that allows particles to be rotated based on a MoLang expression for each axis. This PR also makes some minor changes to the `random_initial_direction/rotation` properties to allow for more fine-grained control.