### PR TITLE
Fix mismatched codec field

### DIFF
--- a/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointAttractorForceData.java
+++ b/common/src/main/java/foundry/veil/api/quasar/data/module/force/PointAttractorForceData.java
@@ -38,7 +38,7 @@ public final class PointAttractorForceData implements ParticleModuleData, Editor
 
     public static final MapCodec<PointAttractorForceData> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             CodecUtil.VECTOR3DC_CODEC.fieldOf("position").forGetter(PointAttractorForceData::position),
-            Codec.BOOL.optionalFieldOf("localPosition", false).forGetter(PointAttractorForceData::invertDistanceModifier),
+            Codec.BOOL.optionalFieldOf("localPosition", false).forGetter(PointAttractorForceData::localPosition),
             Codec.FLOAT.fieldOf("range").forGetter(PointAttractorForceData::range),
             Codec.FLOAT.fieldOf("strength").forGetter(PointAttractorForceData::strength),
             Codec.BOOL.fieldOf("strengthByDistance").forGetter(PointAttractorForceData::strengthByDistance),


### PR DESCRIPTION
The `veil:point_attractor` Quasar module has a broken codec: the `localPosition` property points to `PointAttractorForceData::invertDistanceModifier` instead of `PointAttractorForceData::localPosition` like it should. This PR fixes this to point to the correct variable.