### PR TITLE
Update ImGui configuration in load method

### DIFF
--- a/common/src/main/java/foundry/veil/impl/client/imgui/VeilImGuiCompat.java
+++ b/common/src/main/java/foundry/veil/impl/client/imgui/VeilImGuiCompat.java
@@ -22,7 +22,7 @@ public final class VeilImGuiCompat {
     }
 
     public static void load() {
-        ImGuiMCEvents.INSTANCE.imGuiLoadPre(() -> ImGui.getIO().addConfigFlags(ImGuiConfigFlags.DockingEnable | ImGuiConfigFlags.ViewportsEnable));
+        ImGuiMCEvents.INSTANCE.imGuiLoadPre(() -> ImGui.getIO().addConfigFlags(ImGuiConfigFlags.DockingEnable));
         ImGuiMCEvents.INSTANCE.preRenderImGuiEvent(() -> {
             VeilImGuiStylesheet.initStyles();
             AdvancedFboImGuiAreaImpl.begin();


### PR DESCRIPTION
Removed ViewportsEnable flag from ImGui configuration. This fixes the black screen on macos 26/27.