### PR TITLE
Fix flipped Quasar UVs

### DIFF
--- a/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
+++ b/common/src/main/resources/assets/veil/pinwheel/shaders/program/quasar/particle.vsh
@@ -28,10 +28,10 @@ void main() {
     gl_Position = ProjMat * WorldPosition;
     vertexDistance = length(WorldPosition.xyz);
     vec2 uvs[4];
-    uvs[0] = UV0Min,
-    uvs[1] = vec2(UV0Min.x, UV0Max.y),
-    uvs[2] = UV0Max,
-    uvs[3] = vec2(UV0Max.x, UV0Min.y);
+    uvs[0] = UV0Max;
+    uvs[1] = vec2(UV0Max.x, UV0Min.y);
+    uvs[2] = UV0Min;
+    uvs[3] = vec2(UV0Min.x, UV0Max.y);
     texCoord0 = uvs[gl_VertexID % 4];
     #ifdef VEIL_LIGHT_UV
     // #veil:light_uv


### PR DESCRIPTION
In #172, I accidentally made the UVs for quasar particles flipped, which resulted in every particle appear upside down. This PR corrects that error.
Before:
<img width="559" height="549" alt="An image of the particles appearing upside down." src="https://github.com/user-attachments/assets/9e236ec4-1173-42ea-a64e-56c7ae71710b" />
After:
<img width="462" height="408" alt="Screenshot 2026-08-09 154015" src="https://github.com/user-attachments/assets/ed4a44ac-fb67-42f9-bdd5-90196596238d" />
