### PR TITLE
BugFix the Necromancer Animation classes, now is usable

### DIFF
--- a/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
+++ b/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
@@ -6,14 +6,30 @@ import org.joml.Quaternionfc;
 
 // todo: support cubic interpolation w/ derivatives
 public enum Interpolation {
-    NEAREST_NEIGHBOR(
-            (a, b, t) -> t < 1 ? a : b,
-            (a, b, t, result) -> result.set(t < 0.5 ? a : b)
+    STEP(
+            (a, b, t) -> t < 1F ? a : b,
+            (a, b, t, result) -> result.set(t < 1 ? a : b)
     ),
     LINEAR(
-            (a, b, t) -> Mth.lerp(t, a, b),
+            (a, b, t) -> MathHelper.lerp(t, a, b),
             Quaternionfc::slerp
+    ),
+    EASE_IN(
+            (a, b, t) -> MathHelper.lerp(t * t, a, b),
+            (a, b, t, result) -> result.set(a).slerp(b, t * t)
+    ),
+    EASE_OUT(
+            (a, b, t) -> MathHelper.lerp(1F - (1F - t) * (1F - t), a, b),
+            (a, b, t, result) -> result.set(a).slerp(b, 1F - (1F - t) * (1F - t))
+    ),
+    EASE_IN_OUT(
+            (a, b, t) -> MathHelper.lerp(easeInOut(t), a, b),
+            (a, b, t, result) -> result.set(a).slerp(b, easeInOut(t))
     );
+
+    private static float easeInOut(float t) {
+        return t < 0.5F ? 2F * t * t : 1F - (float) Math.pow(-2F * t + 2F, 2) / 2F;
+    }
 
     private final FloatInterpolator fInterpolator;
     private final QuaternionInterpolator qInterpolator;

--- a/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
+++ b/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
@@ -7,7 +7,7 @@ import org.joml.Quaternionfc;
 // todo: support cubic interpolation w/ derivatives
 public enum Interpolation {
     NEAREST_NEIGHBOR(
-            (a, b, t) -> t < 0.5 ? a : b,
+            (a, b, t) -> t < 1 ? a : b,
             (a, b, t, result) -> result.set(t < 0.5 ? a : b)
     ),
     LINEAR(

--- a/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
+++ b/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/Interpolation.java
@@ -1,31 +1,51 @@
 package foundry.veil.api.client.necromancer.animation.keyframe;
 
 import net.minecraft.util.Mth;
+import org.jetbrains.annotations.ApiStatus;
 import org.joml.Quaternionf;
 import org.joml.Quaternionfc;
 
 // todo: support cubic interpolation w/ derivatives
 public enum Interpolation {
+    /**
+     * @since 4.5.0
+     */
     STEP(
             (a, b, t) -> t < 1F ? a : b,
             (a, b, t, result) -> result.set(t < 1 ? a : b)
     ),
     LINEAR(
-            (a, b, t) -> MathHelper.lerp(t, a, b),
+            (a, b, t) -> Mth.lerp(t, a, b),
             Quaternionfc::slerp
     ),
+    /**
+     * @since 4.5.0
+     */
     EASE_IN(
-            (a, b, t) -> MathHelper.lerp(t * t, a, b),
+            (a, b, t) -> Mth.lerp(t * t, a, b),
             (a, b, t, result) -> result.set(a).slerp(b, t * t)
     ),
+    /**
+     * @since 4.5.0
+     */
     EASE_OUT(
-            (a, b, t) -> MathHelper.lerp(1F - (1F - t) * (1F - t), a, b),
+            (a, b, t) -> Mth.lerp(1F - (1F - t) * (1F - t), a, b),
             (a, b, t, result) -> result.set(a).slerp(b, 1F - (1F - t) * (1F - t))
     ),
+    /**
+     * @since 4.5.0
+     */
     EASE_IN_OUT(
-            (a, b, t) -> MathHelper.lerp(easeInOut(t), a, b),
+            (a, b, t) -> Mth.lerp(easeInOut(t), a, b),
             (a, b, t, result) -> result.set(a).slerp(b, easeInOut(t))
     );
+
+    /**
+     * @deprecated Use {@link #STEP} instead
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "5.0.0")
+    @Deprecated
+    public static final Interpolation NEAREST_NEIGHBOR = STEP;
 
     private static float easeInOut(float t) {
         return t < 0.5F ? 2F * t * t : 1F - (float) Math.pow(-2F * t + 2F, 2) / 2F;

--- a/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/KeyframeTimeline.java
+++ b/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/KeyframeTimeline.java
@@ -13,11 +13,11 @@ public record KeyframeTimeline(Keyframe[] keyframes) {
         listToPopulate[0] = keyframes[previousIndex];
 
         int nextIndex = currentIndex + 1;
-        nextIndex = looped ? nextIndex % keyframes.length : Math.max(nextIndex, keyframes.length - 1);
+        nextIndex = looped ? nextIndex % keyframes.length : Math.min(nextIndex, keyframes.length - 1);
         listToPopulate[2] = keyframes[nextIndex];
 
         int nextNextIndex = currentIndex + 2;
-        nextNextIndex = looped ? nextNextIndex % keyframes.length : Math.max(nextNextIndex, keyframes.length - 1);
+        nextNextIndex = looped ? nextNextIndex % keyframes.length : Math.min(nextNextIndex, keyframes.length - 1);
         listToPopulate[3] = keyframes[nextNextIndex];
 
         // interpolation factor between the two keyframes
@@ -43,12 +43,11 @@ public record KeyframeTimeline(Keyframe[] keyframes) {
             float t1 = keyframes[mid].time();
             float t2 = keyframes[mid + 1].time();
 
-            // current time is between these two keyframes!
-            if (time > t1 && time < t2) {
+            if (time >= t1 && time < t2) {
                 return mid;
             } else if (time > t1) {
                 low = mid + 1;
-            } else if (time < t1) {
+            } else {
                 high = mid - 1;
             }
         }

--- a/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/KeyframedAnimation.java
+++ b/common/src/main/java/foundry/veil/api/client/necromancer/animation/keyframe/KeyframedAnimation.java
@@ -61,7 +61,7 @@ public class KeyframedAnimation<P extends SkeletonParent<?, ?>, S extends Skelet
                         Mth.lerp(mixFactor, 1, interpolation.interpolate(a.transform().sz(), b.transform().sz(), t))
                 );
             } else {
-                bone.size.set(
+                bone.position.set(
                         Mth.lerp(mixFactor, bone.position.x, interpolation.interpolate(a.transform().px(), b.transform().px(), t)),
                         Mth.lerp(mixFactor, bone.position.y, interpolation.interpolate(a.transform().py(), b.transform().py(), t)),
                         Mth.lerp(mixFactor, bone.position.z, interpolation.interpolate(a.transform().pz(), b.transform().pz(), t))
@@ -79,16 +79,16 @@ public class KeyframedAnimation<P extends SkeletonParent<?, ?>, S extends Skelet
         }
     }
 
-    public static class Builder {
+    public static class Builder<P extends SkeletonParent<?, ?>, S extends Skeleton> {
         boolean looped = false, additive = false;
         Map<String, List<Keyframe>> timelines = new HashMap<>();
 
-        Builder looped(boolean isLooped) {
+        public Builder<P, S> looped(boolean isLooped) {
             this.looped = isLooped;
             return this;
         }
 
-        Builder additive(boolean isAdditive) {
+        public Builder<P, S> additive(boolean isAdditive) {
             this.additive = isAdditive;
             return this;
         }
@@ -104,7 +104,7 @@ public class KeyframedAnimation<P extends SkeletonParent<?, ?>, S extends Skelet
             timelines.get(boneId).add(new Keyframe(time, interpolation, new Keyframe.KeyframeTransform(position, size, orientation)));
         }
 
-        public KeyframedAnimation<?, ?> build() {
+        public KeyframedAnimation<P, S> build() {
             Map<String, KeyframeTimeline> builtTimelines = new HashMap<>();
             for (Map.Entry<String, List<Keyframe>> timeline : timelines.entrySet()) {
                 List<Keyframe> keyframeList = timeline.getValue();


### PR DESCRIPTION
BugFixes:
- KeyframeTimeline
   - `ArrayIndexOutOfBoundsException` becuase `Math.max(nextIndex, keyframes.length - 1);` and `Math.max(nextNextIndex, keyframes.length - 1);`
   - on `findKeyframeIndex`, there is no check for `time == t1`
 
 - KeyframedAnimation
   - `bone.size.set()` when setting the position
   - `tempRotationA.identity()` will cause to not rotate when mixFactor = 1'
   - changes on the **API**, to prevent `unchecked-cast warning` on `this.addAnimation((Animation<ModelEntity, ModelSkeleton>) builder1.build(), priotity);`